### PR TITLE
handle wheel-only packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ htmlcov/
 *.pyc
 __pycache__/
 .pytest_cache/
+smoke-tests/
 *.snappy-*.tar.gz
 *.so
 *.sqlite

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -11,8 +11,8 @@
 make full-run \
     -e PACKAGE_NAME=apache-airflow
 
-# FAILS after "searching for source artifact"
-# wheel-only distribution?
+# wheel-only distribution
+# 7.0MB of JavaScript
 make full-run \
     -e PACKAGE_NAME=catboost
 
@@ -64,10 +64,9 @@ make full-run \
     -e PACKAGE_NAME=xgboost
 ```
 
-### Cuurrently broken
+### Currently broken
 
 ```text
-catboost
 tensorflow (weird 15M in the data frame)
 torch
 ```

--- a/bin/full-run.sh
+++ b/bin/full-run.sh
@@ -28,41 +28,51 @@ SOURCE_FILE=$(
     cat "${ARTIFACTS_CSV}" \
     | grep -E '\.tar\.gz,|\.zip,' \
     | head -1 \
-    | awk -F"," '{print $1}'
+    | awk -F"," '{print $1}' \
+    || echo ""
 )
-echo "source artifact: '${SOURCE_FILE}'"
+if [[ "${SOURCE_FILE}" == "" ]]; then
+    echo "[WARNING] no source artifacts (.tar.gz or .zip) found"
+else
+    echo "source artifact: '${SOURCE_FILE}'"
 
-bin/download-package.sh \
-    "${ARTIFACTS_CSV}" \
-    "${SOURCE_FILE}" \
-    "${OUTPUT_DIR}"
+    bin/download-package.sh \
+        "${ARTIFACTS_CSV}" \
+        "${SOURCE_FILE}" \
+        "${OUTPUT_DIR}"
 
-bin/summarize.sh \
-    "${OUTPUT_DIR}/${SOURCE_FILE}" \
-    "${SOURCE_SIZES_CSV}" \
-    "${OUTPUT_DIR}"
+    bin/summarize.sh \
+        "${OUTPUT_DIR}/${SOURCE_FILE}" \
+        "${SOURCE_SIZES_CSV}" \
+        "${OUTPUT_DIR}"
 
-python bin/summarize-sizes.py \
-    "${SOURCE_SIZES_CSV}"
+    python bin/summarize-sizes.py \
+        "${SOURCE_SIZES_CSV}"
+fi
 
 echo "searching for a wheel"
 WHEEL_FILE=$(
     cat "${ARTIFACTS_CSV}" \
     | grep -E '.*any.*\.whl,' \
     | head -1 \
-    | awk -F"," '{print $1}'
+    | awk -F"," '{print $1}' \
+    || echo ""
 )
-echo "wheel: '${WHEEL_FILE}'"
+if [[ "${WHEEL_FILE}" == "" ]]; then
+    echo "[WARNING] no wheels (.whl) found"
+else
+    echo "wheel: '${WHEEL_FILE}'"
 
-bin/download-package.sh \
-    "${ARTIFACTS_CSV}" \
-    "${WHEEL_FILE}" \
-    "${OUTPUT_DIR}"
+    bin/download-package.sh \
+        "${ARTIFACTS_CSV}" \
+        "${WHEEL_FILE}" \
+        "${OUTPUT_DIR}"
 
-bin/summarize.sh \
-    "${OUTPUT_DIR}/${WHEEL_FILE}" \
-    "${WHEEL_SIZES_CSV}" \
-    "${OUTPUT_DIR}"
+    bin/summarize.sh \
+        "${OUTPUT_DIR}/${WHEEL_FILE}" \
+        "${WHEEL_SIZES_CSV}" \
+        "${OUTPUT_DIR}"
 
-python bin/summarize-sizes.py \
-    "${WHEEL_SIZES_CSV}"
+    python bin/summarize-sizes.py \
+        "${WHEEL_SIZES_CSV}"
+fi


### PR DESCRIPTION
`catboost` does not publish a source distribution to PyPI...only wheels.

See https://pypi.org/project/catboost/#files.

Currently, `full-run.sh` assumes that every package will have a wheel and a source distribution. This PR alters that script to account for the possibility of wheel-only or source-only distributions.

### How I tested this

```shell
make full-run \
    -e PACKAGE_NAME=catboost
```