### PR TITLE
[ci] add a check-package-manually job

### DIFF
--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -3,7 +3,7 @@ name: manual-run
 on:
   workflow_dispatch:
     inputs:
-      username:
+      package_name:
         description: 'Name of a package on PyPI'
         required: true
         type: string


### PR DESCRIPTION
Following https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow and https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions, this PR proposes adding a GitHub Actions job that will manually inspect one package on PyPI.

Thought this could be a fun way to let other people try the project without needing to run it themselves.