### PR TITLE
separate wheel and source distribution

### DIFF
--- a/bin/full-run.sh
+++ b/bin/full-run.sh
@@ -12,6 +12,8 @@ if [ -d "${OUTPUT_DIR}" ]; then
 else
     echo "creating directory '${OUTPUT_DIR}'"
     mkdir -p "${OUTPUT_DIR}"
+    mkdir -p "${OUTPUT_DIR}/source"
+    mkdir -p "${OUTPUT_DIR}/wheel"
 fi
 
 ARTIFACTS_CSV="${OUTPUT_DIR}/artifacts.csv"
@@ -40,12 +42,12 @@ else
     bin/download-package.sh \
         "${ARTIFACTS_CSV}" \
         "${SOURCE_FILE}" \
-        "${OUTPUT_DIR}"
+        "${OUTPUT_DIR}/source"
 
     bin/summarize.sh \
-        "${OUTPUT_DIR}/${SOURCE_FILE}" \
+        "${OUTPUT_DIR}/source/${SOURCE_FILE}" \
         "${SOURCE_SIZES_CSV}" \
-        "${OUTPUT_DIR}" \
+        "${OUTPUT_DIR}/source" \
         "${LINTER_BIN_DIR}"
 
     python bin/summarize-sizes.py \
@@ -68,12 +70,12 @@ else
     bin/download-package.sh \
         "${ARTIFACTS_CSV}" \
         "${WHEEL_FILE}" \
-        "${OUTPUT_DIR}"
+        "${OUTPUT_DIR}/wheel"
 
     bin/summarize.sh \
-        "${OUTPUT_DIR}/${WHEEL_FILE}" \
+        "${OUTPUT_DIR}/wheel/${WHEEL_FILE}" \
         "${WHEEL_SIZES_CSV}" \
-        "${OUTPUT_DIR}" \
+        "${OUTPUT_DIR}/wheel" \
         "${LINTER_BIN_DIR}"
 
     python bin/summarize-sizes.py \

--- a/bin/summarize.sh
+++ b/bin/summarize.sh
@@ -30,7 +30,7 @@ cp "${ARTIFACT_NAME}" "${TEMP_PATH}/${TEMP_FILE_NAME}"
 pushd "${TEMP_PATH}"
 
 echo "checking compressed size..."
-du --si ./"${TEMP_FILE_NAME}"
+du ./"${TEMP_FILE_NAME}"
 
 echo "decompressing..."
 if [[ "${FILE_EXTENSION}" == ".tar.gz" ]]; then


### PR DESCRIPTION
Currently, `make full-run` unpacks source distributions and wheels into the same directory. This could lead to incorrect reporting of the contents of wheels.

This PR fixes that, by explicitly putting wheels and source distributions in separate directories.