### PR TITLE
[docs] set up readthedocs site (fixes #31)

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -20,10 +20,10 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           environment-file: docs/env.yml
+          activate-environment: pydistscheck-docs
           miniforge-variant: Mambaforge
           use-mamba: true
       - name: run tests
+        shell: bash -l {0}
         run: |
-          export PATH="${CONDA}/bin:$HOME/.local/bin:${PATH}"
-          source activate pydistscheck-docs
           make -C ./docs html

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -20,10 +20,9 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           environment-file: docs/env.yml
-          activate-environment: pydistscheck-docs
           miniforge-variant: Mambaforge
           use-mamba: true
       - name: run tests
         run: |
-          source activte pydistscheck-docs
+          source activate pydistscheck-docs
           make -C ./docs html

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -23,7 +23,7 @@ jobs:
           activate-environment: pydistscheck-docs
           miniforge-variant: Mambaforge
           use-mamba: true
-      - name: run tests
+      - name: build docs
         shell: bash -l {0}
         run: |
           make -C ./docs html

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -24,5 +24,6 @@ jobs:
           use-mamba: true
       - name: run tests
         run: |
+          export PATH="${CONDA}/bin:$HOME/.local/bin:${PATH}"
           source activate pydistscheck-docs
           make -C ./docs html

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -25,5 +25,5 @@ jobs:
           use-mamba: true
       - name: run tests
         run: |
-          cd docs
-          make html
+          source activte pydistscheck-docs
+          make -C ./docs html

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,0 +1,29 @@
+name: docs
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  test:
+    name: check-docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          environment-file: docs/env.yml
+          activate-environment: pydistscheck-docs
+          miniforge-variant: Mambaforge
+          use-mamba: true
+      - name: run tests
+        run: |
+          cd $BUILD_DIRECTORY/docs
+          make html

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -25,5 +25,5 @@ jobs:
           use-mamba: true
       - name: run tests
         run: |
-          cd $BUILD_DIRECTORY/docs
+          cd docs
           make html

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.7zip
 *.a
 *.bak
+_build/
 *.bz
 *.core
 *.coverage

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"
+conda:
+  environment: docs/env.yml
+formats:
+  - pdf
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+submodules:
+  include: all
+  recursive: true

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    = -W
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,22 +6,21 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'pydistcheck'
-copyright = '2022, James Lamb'
-author = 'James Lamb'
+project = "pydistcheck"
+copyright = "2022, James Lamb"
+author = "James Lamb"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = []
 
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
-
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,27 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'pydistcheck'
+copyright = '2022, James Lamb'
+author = 'James Lamb'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = []
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -1,0 +1,8 @@
+name: pydistscheck-docs
+channels:
+  - nodefaults
+  - conda-forge
+dependencies:
+  - python=3.10
+  - sphinx
+  - "sphinx_rtd_theme>=0.5"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+.. pydistcheck documentation master file, created by
+   sphinx-quickstart on Sun Jul 31 23:30:36 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to pydistcheck's documentation!
+=======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`


### PR DESCRIPTION
Fixes #31.

Sets up the structure of a documentation site.

Also adds a CI job building the docs.

### How I Set this Up

Used `sphinx-quickstart`, following https://www.sphinx-doc.org/en/master/usage/quickstart.html.

Added automatic builds of `main` at https://readthedocs.org/projects/pydistcheck.