### PR TITLE
[ci] split up CI jobs, run smoke tests on multiple OSes

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,48 @@
+name: smoke-tests
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  test:
+    name: smoke-tests (${{ matrix.os }}, $${{ matrix.python_version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python_version: 3.8
+          - os: macOS-latest
+            python_version: 3.8
+          - os: windows-latest
+            python_version: 3.8
+    steps:
+      - name: Prevent conversion of line endings on Windows
+        if: startsWith(matrix.os, 'windows')
+        shell: pwsh
+        run: git config --global core.autocrlf false
+      - name: check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: pydistscheck-tests
+          miniforge-variant: Mambaforge
+          use-mamba: true
+          python-version: "${{ matrix.python_version}}"
+      - name: run tests
+        run: |
+          mamba install --yes \
+            numpy \
+            pandas \
+            pipx \
+            jq
+          make smoke-tests

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    name: smoke-tests (${{ matrix.os }}, $${{ matrix.python_version }})
+    name: smoke-tests (${{ matrix.os }}, ${{ matrix.python_version }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
@@ -37,12 +37,15 @@ jobs:
           activate-environment: pydistscheck-tests
           miniforge-variant: Mambaforge
           use-mamba: true
-          python-version: "${{ matrix.python_version}}"
+          python-version: ${{ matrix.python_version }}
       - name: run tests
+        shell: bash
         run: |
-          mamba install --yes \
-            numpy \
-            pandas \
-            pipx \
-            jq
+          mamba install \
+            --yes \
+            --name pydistscheck-tests \
+              jq \
+              numpy \
+              pandas \
+              pipx
           make smoke-tests

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -39,7 +39,7 @@ jobs:
           use-mamba: true
           python-version: ${{ matrix.python_version }}
       - name: run tests
-        shell: bash
+        shell: bash -l {0}
         run: |
           mamba install \
             --yes \

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -48,4 +48,6 @@ jobs:
               numpy \
               pandas \
               pipx
+          make build
+          pip install dist/*.tar.gz
           make smoke-tests

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -44,10 +44,17 @@ jobs:
           mamba install \
             --yes \
             --name pydistscheck-tests \
-              jq \
               numpy \
               pandas \
               pipx
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            chocolatey install jq
+          else
+            mamba install \
+              --yes \
+              --name pydistscheck-tests \
+                jq
+          fi
           make build
           pip install dist/*.tar.gz
           make smoke-tests

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,4 +1,4 @@
-name: tests
+name: static-analysis
 
 on:
   push:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -26,26 +26,3 @@ jobs:
               black \
               shellcheck
           make lint
-  smoke-tests:
-    name: smoke-tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: check out repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-      - name: run tests
-        run: |
-          export PATH="/usr/share/miniconda/bin:${PATH}"
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            jq
-          pip install --user \
-              pipx
-          pipx ensurepath
-          conda install \
-            --yes \
-            -c conda-forge \
-              numpy \
-              pandas
-          make smoke-tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.7zip
 *.a
 *.bak
+build/
 _build/
 *.bz
 *.core

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lint:
 		.
 
 .PHONY: smoke-tests
-smoke-tests: build install
+smoke-tests:
 	@echo "running smoke tests" && \
 	mkdir -p ./smoke-tests
 	# wheel-only package


### PR DESCRIPTION
* makes `static-analysis` a standalone GitHub Actions workflows
* expands smoke tests to run on Linux, Mac, and Windows