### PR TITLE
add summary CI jobs for branch protections

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -58,3 +58,10 @@ jobs:
           make build
           pip install dist/*.tar.gz
           make smoke-tests
+  all-unit-tests-successful:
+    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+    - name: Note that all tests succeeded
+      run: echo "🎉"

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -58,7 +58,7 @@ jobs:
           make build
           pip install dist/*.tar.gz
           make smoke-tests
-  all-unit-tests-successful:
+  all-smoke-tests-successful:
     # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
     runs-on: ubuntu-latest
     needs: [test]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           pip install '.[tests]'
           make test
-  all-successful:
+  all-unit-tests-successful:
     # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
     runs-on: ubuntu-latest
     needs: [test-cpython, test-pypy]


### PR DESCRIPTION
Follow-up to #36 .

GitHub branch protections allow blocking merges until certain GitHub Actions jobs pass.
Unfortunately, the logic for that relies on job *names*.

<img width="766" alt="image" src="https://user-images.githubusercontent.com/7608904/186327650-72835d3d-b1b3-40dd-91e9-d69edbb7086e.png">

This project's CI job names include information like the version of Python.
As new versions of Python are released and older ones reach end-of-life, that set of job names will change.

This PR adds "all successful" jobs that will only pass if all other jobs in a given workflow succeed, to avoid needing to manually update the list of passing tests whenever the set of CI jobs changes.