### PR TITLE
[ci] limit smoke tests to Linux

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -19,15 +19,7 @@ jobs:
         include:
           - os: ubuntu-latest
             python_version: 3.8
-          - os: macOS-latest
-            python_version: 3.8
-          - os: windows-latest
-            python_version: 3.8
     steps:
-      - name: Prevent conversion of line endings on Windows
-        if: startsWith(matrix.os, 'windows')
-        shell: pwsh
-        run: git config --global core.autocrlf false
       - name: check out repository
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This project's smoke tests take longer to run than its unit tests.
The Windows and macOS smoke tests are slower than the Linux tests, and therefore end up determining how long it takes for a PR to be mergeable.

Now that unit tests covering Linux, Windows, and macOS have been added (#30), I don't think it's necessary to run the smoke tests on 3 operating systems.

This PR proposes limiting the smoke tests to just Linux, to reduce CI time.