### PR TITLE
[ci] start publishing wheels

### DIFF
--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -19,6 +19,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.9.0
+        env:
+          CIBW_TEST_COMMAND: >
+            pytest {project}/tests
+          CIBW_TEST_EXTRAS: tests
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -1,6 +1,6 @@
 name: build-and-publish-to-pypi
 
-# build wheels and push to PyPI whenever 
+# build wheels and push to PyPI whenever a GitHub release is published
 on:
   push:
   pull_request:

--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -3,9 +3,11 @@ name: build-and-publish-to-pypi
 # build wheels and push to PyPI whenever a GitHub release is published
 on:
   push:
-    # branches:
-    # - build/*
+    branches:
+    - build/*
   pull_request:
+    branches:
+    - build/*
   release:
     types:
       - published

--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -3,6 +3,8 @@ name: build-and-publish-to-pypi
 # build wheels and push to PyPI whenever a GitHub release is published
 on:
   push:
+    # branches:
+    # - build/*
   pull_request:
   release:
     types:
@@ -10,22 +12,15 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+    name: build wheels
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.9.0
-        env:
-          CIBW_TEST_COMMAND: >
-            pytest {project}/tests
-          CIBW_TEST_EXTRAS: tests
+        run: pipx run build --wheel
       - uses: actions/upload-artifact@v3
         with:
-          path: ./wheelhouse/*.whl
+          path: dist/*.whl
 
   build_sdist:
     name: Build source distribution

--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -1,0 +1,53 @@
+name: build-and-publish-to-pypi
+
+# build wheels and push to PyPI whenever 
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - published
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-11]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.9.0
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build sdist
+        run: pipx run build --sdist
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # publish whenever a GitHub release is published
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@v1.5.1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_KEY }}
+
+# adopted from:
+# https://github.com/pypa/cibuildwheel/blob/0117165b02675521b3db2d05033747819bb3ecc5/examples/github-deploy.yml

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,3 @@ tests = file: requirements-tests.txt
 
 [options.packages.find]
 where = src
-
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
Contributes to #39.

Adds a GitHub Actions job that builds wheels with `cibuildwheel` and pushes them to PyPI.

Based on https://github.com/pypa/cibuildwheel/blob/0117165b02675521b3db2d05033747819bb3ecc5/examples/github-deploy.yml.