### PR TITLE
[ci] automatically upload distributions to release

### DIFF
--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -50,5 +50,24 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_KEY }}
 
+  upload_github:
+    needs: [upload_pypi]
+    runs-on: ubuntu-latest
+    # publish whenever a GitHub release is published
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+    - name: upload distributions to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: dist/*
+        file_glob: true
+        tag: ${{ github.ref }}
+        overwrite: false
+
 # adopted from:
 # https://github.com/pypa/cibuildwheel/blob/0117165b02675521b3db2d05033747819bb3ecc5/examples/github-deploy.yml


### PR DESCRIPTION
Contributes to #39.

Adds a task to upload source distribution + wheel(s) to GitHub releases page whenever a GitHub release is created.

### References

https://github.com/svenstaro/upload-release-action