### PR TITLE
[docs] add Check reference to docs

### DIFF
--- a/docs/check-reference.rst
+++ b/docs/check-reference.rst
@@ -1,0 +1,21 @@
+Check Reference
+===============
+
+This page describes each of the checks that ``pydistcheck`` performs.
+The section headings correspond to the error codes printed in ``pydistcheck``'s output.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+too-many-files
+**************
+
+``too-many-files`` is raised whenever ``pydistcheck`` encounters a package distribution
+that contains more than the allowed number of files.
+
+This is a very very rough way to detect that unexpected files have been included in a new release of a project.
+
+``pydistcheck`` defaults to raising this error when a distribution has more than 2000 files...a totally arbitrary number chosen by the author.
+
+To change that limit, use configuration option ``max-allowed-files``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,20 +1,18 @@
-.. pydistcheck documentation master file, created by
-   sphinx-quickstart on Sun Jul 31 23:30:36 2022.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+pydistcheck
+===========
 
-Welcome to pydistcheck's documentation!
-=======================================
+``pydistcheck`` is a command-line interface (CLI) used to detect problematic characteristics
+in Python package distributions.
+
+It is intended to be used in continuous integration and interactively during development.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Contents:
 
-
+   Check Reference <check-reference>
 
 Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`

--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -4,7 +4,7 @@ from pydistcheck.distribution_summary import _DistributionSummary
 
 class _FileCountCheck:
 
-    check_name = "too-many-files"
+    name = "too-many-files"
 
     def __init__(self, max_allowed_files: int):
         self.max_allowed_files = max_allowed_files
@@ -13,6 +13,6 @@ class _FileCountCheck:
         out: List[str] = []
         num_files = distro_summary.num_files
         if num_files > self.max_allowed_files:
-            msg = f"[{self.check_name}] Found {num_files} files. Only {self.max_allowed_files} allowed."
+            msg = f"[{self.name}] Found {num_files} files. Only {self.max_allowed_files} allowed."
             out.append(msg)
         return out

--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -4,7 +4,7 @@ from pydistcheck.distribution_summary import _DistributionSummary
 
 class _FileCountCheck:
 
-    name = "too-many-files"
+    check_name = "too-many-files"
 
     def __init__(self, max_allowed_files: int):
         self.max_allowed_files = max_allowed_files
@@ -13,6 +13,6 @@ class _FileCountCheck:
         out: List[str] = []
         num_files = distro_summary.num_files
         if num_files > self.max_allowed_files:
-            msg = f"[{self.name}] Found {num_files} files. Only {self.max_allowed_files} allowed."
+            msg = f"[{self.check_name}] Found {num_files} files. Only {self.max_allowed_files} allowed."
             out.append(msg)
         return out


### PR DESCRIPTION
Contributes to #14.
Contributes to #46.

Adds a page to the documentation that contains a long-form description of each issue that `pydistcheck` checks for.

Adds a short description to the docs home page.