### PR TITLE
[docs] make template active-voice

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-check.yml
+++ b/.github/ISSUE_TEMPLATE/new-check.yml
@@ -1,4 +1,4 @@
-name: New Check Requests
+name: Request a new check
 description: Request that `pydistcheck` complain about something it doesn't complain about today.
 title: "new check: "
 labels: ["enhancemment"]


### PR DESCRIPTION
follow-up to #49 

I think all the issue template prompts should be in active voice, like "request a new check", "report a bug", etc.