### PR TITLE
[docs] add template for feature requests (fixes #48)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,26 @@
+name: Request some other new feature
+description: Request some feature other than "a new check.
+title: "[feature request] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to recommend improvements to `pydistcheck`!
+  - type: textarea
+    attributes:
+      label: What change would you like to see?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: How would implementing this improve `pydistcheck`?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Notes
+      description: |
+        Anything else you want to share?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/new-check.yml
+++ b/.github/ISSUE_TEMPLATE/new-check.yml
@@ -1,6 +1,6 @@
 name: Request a new check
 description: Request that `pydistcheck` complain about something it doesn't complain about today.
-title: "new check: "
+title: "[new check] "
 labels: ["enhancement"]
 body:
   - type: markdown
@@ -51,12 +51,12 @@ body:
       options:
         - label: source (e.g. `.tar.gz`)
           required: false
-        - label: built(e.g. `.whl`)
+        - label: built (e.g. `.whl`)
           required: false
   - type: textarea
     attributes:
       label: Notes
       description: |
-        Anything else people should know?
+        Anything else you want to share?
     validations:
       required: false


### PR DESCRIPTION
Fixes #48.

Adds a template for feature requests that are anything other than "please add this check".

Also cleans up some miscellaneous stuff in the template for requesting a new check.