### PR TITLE
resolve pylint warnings: unused imports

### DIFF
--- a/src/pydistcheck/_compat.py
+++ b/src/pydistcheck/_compat.py
@@ -1,3 +1,5 @@
+# pylint: disable=unused-import
+
 try:
     import tomllib
 except ModuleNotFoundError:

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import click
+from typing import Dict, List, Optional, Union
 from pydistcheck._compat import tomllib
 from pydistcheck.checks import (
     _DistroTooLargeCompressedCheck,
@@ -12,8 +13,6 @@ from pydistcheck.distribution_summary import (
     summarize_distribution_contents,
 )
 from pydistcheck.utils import _FileSize
-
-from typing import Any, Dict, List, Optional, Union
 
 
 @click.group()


### PR DESCRIPTION
Contributes to #21.

Resolves the following warnings from `pylint`.

> src/pydistcheck/cli.py:16:0: C0411: standard import "from typing import Any, Dict, List, Optional, Union" should be placed before "import click" (wrong-import-order)
src/pydistcheck/cli.py:16:0: W0611: Unused Any imported from typing (unused-import)
src/pydistcheck/_compat.py:2:4: W0611: Unused import tomllib (unused-import)
src/pydistcheck/_compat.py:4:4: W0611: Unused tomli imported as tomllib (unused-import)


### How I tested this

```shell
pylint ./src
```