### PR TITLE
resolve pylint warnings: ignore unnecessary checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,12 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
+
+[tool.pylint.messages_control]
+
+max-line-length = 100
+
+disable = [
+  "invalid-name",
+  "too-few-public-methods"
+]


### PR DESCRIPTION
Contributes to #21.

Suppresses the following warnings from `pylint`.

> src/pydistcheck/checks.py:6:0: R0903: Too few public methods (1/2) (too-few-public-methods)
src/pydistcheck/checks.py:23:0: R0903: Too few public methods (1/2) (too-few-public-methods)
src/pydistcheck/checks.py:40:0: R0903: Too few public methods (1/2) (too-few-public-methods)
src/pydistcheck/cli.py:24:45: C0103: Variable name "f" doesn't conform to snake_case naming style (invalid-name)
src/pydistcheck/cli.py:83:45: C0103: Variable name "f" doesn't conform to snake_case naming style (invalid-name)
src/pydistcheck/distribution_summary.py:52:56: C0103: Variable name "tf" doesn't conform to snake_case naming style (invalid-name)
src/pydistcheck/distribution_summary.py:56:56: C0103: Variable name "f" doesn't conform to snake_case naming style (invalid-name)
src/pydistcheck/distribution_summary.py:75:12: C0103: Variable name "f" doesn't conform to snake_case naming style (invalid-name)
