### PR TITLE
resolve pylint warnings: long lines

### DIFF
--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -17,7 +17,7 @@ class _DistroTooLargeCompressedCheck:
         if actual_size > max_size:
             msg = (
                 f"[{self.check_name}] Compressed size {actual_size} is larger "
-                "than the allowed size ({max_size})."
+                f"than the allowed size ({max_size})."
             )
             out.append(msg)
         return out
@@ -37,7 +37,7 @@ class _DistroTooLargeUnCompressedCheck:
         if actual_size > max_size:
             msg = (
                 f"[{self.check_name}] Uncompressed size {actual_size} is larger "
-                "than the allowed size ({max_size})."
+                f"than the allowed size ({max_size})."
             )
             out.append(msg)
         return out
@@ -56,7 +56,7 @@ class _FileCountCheck:
         if num_files > self.max_allowed_files:
             msg = (
                 f"[{self.check_name}] Found {num_files} files. "
-                "Only {self.max_allowed_files} allowed."
+                f"Only {self.max_allowed_files} allowed."
             )
             out.append(msg)
         return out

--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -15,7 +15,10 @@ class _DistroTooLargeCompressedCheck:
         max_size = _FileSize(num=self.max_allowed_size_bytes, unit_str="B")
         actual_size = _FileSize(num=distro_summary.compressed_size_bytes, unit_str="B")
         if actual_size > max_size:
-            msg = f"[{self.check_name}] Compressed size {actual_size} is larger than the allowed size ({max_size})."
+            msg = (
+                f"[{self.check_name}] Compressed size {actual_size} is larger "
+                "than the allowed size ({max_size})."
+            )
             out.append(msg)
         return out
 
@@ -32,7 +35,10 @@ class _DistroTooLargeUnCompressedCheck:
         max_size = _FileSize(num=self.max_allowed_size_bytes, unit_str="B")
         actual_size = _FileSize(num=distro_summary.uncompressed_size_bytes, unit_str="B")
         if actual_size > max_size:
-            msg = f"[{self.check_name}] Uncompressed size {actual_size} is larger than the allowed size ({max_size})."
+            msg = (
+                f"[{self.check_name}] Uncompressed size {actual_size} is larger "
+                "than the allowed size ({max_size})."
+            )
             out.append(msg)
         return out
 
@@ -48,6 +54,9 @@ class _FileCountCheck:
         out: List[str] = []
         num_files = distro_summary.num_files
         if num_files > self.max_allowed_files:
-            msg = f"[{self.check_name}] Found {num_files} files. Only {self.max_allowed_files} allowed."
+            msg = (
+                f"[{self.check_name}] Found {num_files} files. "
+                "Only {self.max_allowed_files} allowed."
+            )
             out.append(msg)
         return out


### PR DESCRIPTION
Contributes to #21.

Resolves the following warnings from `pylint`.

> src/pydistcheck/checks.py:18:0: C0301: Line too long (116/100) (line-too-long)
src/pydistcheck/checks.py:35:0: C0301: Line too long (118/100) (line-too-long)
src/pydistcheck/checks.py:51:0: C0301: Line too long (104/100) (line-too-long)