### PR TITLE
[ci] enforce pylint checks (fixes #21)

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,5 +24,6 @@ jobs:
             --yes \
             -c conda-forge \
               black \
+              pylint \
               shellcheck
           make lint

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ lint:
 	black \
 		--check \
 		.
+	pylint ./src
 
 .PHONY: smoke-tests
 smoke-tests:

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -4,8 +4,8 @@ CLI entrypoints
 
 import os
 import sys
-import click
 from typing import Dict, List, Optional, Union
+import click
 from pydistcheck._compat import tomllib
 from pydistcheck.checks import (
     _DistroTooLargeCompressedCheck,

--- a/src/pydistcheck/distribution_summary.py
+++ b/src/pydistcheck/distribution_summary.py
@@ -64,15 +64,15 @@ class _DistributionSummary:
 
     @property
     def num_directories(self) -> int:
-        return sum([1 for f in self.file_infos if f.is_directory])
+        return sum(1 for f in self.file_infos if f.is_directory)
 
     @property
     def num_files(self) -> int:
-        return sum([1 for f in self.file_infos if f.is_file])
+        return sum(1 for f in self.file_infos if f.is_file)
 
     @property
     def uncompressed_size_bytes(self) -> int:
-        return sum([f.uncompressed_size_bytes for f in self.file_infos])
+        return sum(f.uncompressed_size_bytes for f in self.file_infos)
 
     @property
     def size_by_file_extension(self) -> defaultdict:
@@ -94,7 +94,7 @@ def summarize_distribution_contents(file: str, output_file: Optional[str] = None
 
     if output_file is not None:
         print(f"writing size-by-extension results to '{output_file}'")
-        with open(output_file, "w", newline="") as f:
+        with open(output_file, "w", encoding="utf-8", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=["extension", "size"])
             writer.writeheader()
             for extension, size in summary.size_by_file_extension.items():

--- a/src/pydistcheck/utils.py
+++ b/src/pydistcheck/utils.py
@@ -12,10 +12,10 @@ _UNIT_TO_NUM_BYTES = {"B": 1, "K": 1024, "M": 1024**2, "G": 1024**3}
 def _recommend_size_str(num_bytes: float) -> Tuple[float, str]:
     if num_bytes < 512:
         return float(num_bytes), "B"
-    elif num_bytes <= (0.5 * 1024**2):
+    if num_bytes <= (0.5 * 1024**2):
         return float(num_bytes) / 1024.0, "K"
-    else:
-        return float(num_bytes) / (1024**2), "M"
+
+    return float(num_bytes) / (1024**2), "M"
 
 
 class _FileSize:


### PR DESCRIPTION
Fixes #21.

Resolves the remaining `pylint` warnings, and starts enforcing that `pylint` pass with 0 findings in CI.

Warnings addressed by this PR:

```text
src/pydistcheck/cli.py:8:0: C0411: standard import "from typing import Dict, List, Optional, Union" should be placed before "import click" (wrong-import-order)
src/pydistcheck/utils.py:13:4: R1705: Unnecessary "elif" after "return", remove the leading "el" from "elif" (no-else-return)
src/pydistcheck/distribution_summary.py:67:15: R1728: Consider using a generator instead 'sum(1 for f in self.file_infos if f.is_directory)' (consider-using-generator)
src/pydistcheck/distribution_summary.py:71:15: R1728: Consider using a generator instead 'sum(1 for f in self.file_infos if f.is_file)' (consider-using-generator)
src/pydistcheck/distribution_summary.py:75:15: R1728: Consider using a generator instead 'sum(f.uncompressed_size_bytes for f in self.file_infos)' (consider-using-generator)
src/pydistcheck/distribution_summary.py:97:13: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
```