### PR TITLE
[ci] enforce flake8 tests (fixes #20)

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,6 +24,7 @@ jobs:
             --yes \
             -c conda-forge \
               black \
+              flake8 \
               pylint \
               shellcheck
           make lint

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ lint:
 	black \
 		--check \
 		.
+	flake8 .
 	pylint ./src
 
 .PHONY: smoke-tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[flake8]
+max-line-length = 100
+
 [metadata]
 name = pydistcheck
 version = file: VERSION.txt

--- a/src/pydistcheck/_compat.py
+++ b/src/pydistcheck/_compat.py
@@ -6,6 +6,6 @@ with a wide range of dependency versions.
 """
 
 try:
-    import tomllib
+    import tomllib  # noqa: F401
 except ModuleNotFoundError:
-    import tomli as tomllib
+    import tomli as tomllib  # noqa: F401

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,6 @@ import os
 import re
 import pytest
 
-from typing import List
 from click.testing import CliRunner, Result
 from pydistcheck.cli import check
 
@@ -11,9 +10,12 @@ TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 def _assert_log_matches_pattern(result: Result, pattern: str) -> None:
     log_lines = result.output.split("\n")
-    match_results = [bool(re.search(pattern, l)) for l in log_lines]
+    match_results = [bool(re.search(pattern, log_line)) for log_line in log_lines]
     num_matches_found = sum(match_results)
-    msg = f"Expected to find 1 instance of '{pattern}' in logs, found {num_matches_found} in {log_lines}."
+    msg = (
+        f"Expected to find 1 instance of '{pattern}' in logs, "
+        f"found {num_matches_found} in {log_lines}."
+    )
     assert num_matches_found == 1, msg
 
 
@@ -59,7 +61,10 @@ def test_check_respects_max_allowed_size_compressed(size_str, distro_file):
 
     _assert_log_matches_pattern(
         result,
-        r"^1\. \[distro\-too\-large\-compressed\] Compressed size [0-9]+\.[0-9]+K is larger than the allowed size \([0-9]+\.[0-9]+[BKMG]\)\.$",
+        (
+            r"^1\. \[distro\-too\-large\-compressed\] Compressed size [0-9]+\.[0-9]+K is "
+            r"larger than the allowed size \([0-9]+\.[0-9]+[BKMG]\)\.$"
+        ),
     )
     _assert_log_matches_pattern(result, "errors found while checking\\: 1")
 
@@ -85,6 +90,9 @@ def test_check_respects_max_allowed_size_uncompressed(size_str, distro_file):
 
     _assert_log_matches_pattern(
         result,
-        r"^1\. \[distro\-too\-large\-uncompressed\] Uncompressed size [0-9]+\.[0-9]+K is larger than the allowed size \([0-9]+\.[0-9]+[BKMG]\)\.$",
+        (
+            r"^1\. \[distro\-too\-large\-uncompressed\] Uncompressed size [0-9]+\.[0-9]+K is "
+            r"larger than the allowed size \([0-9]+\.[0-9]+[BKMG]\)\.$"
+        ),
     )
     _assert_log_matches_pattern(result, "errors found while checking\\: 1")


### PR DESCRIPTION
Fixes #20.

Enforces `flake8` checks in CI, and resolves the following warnings.

```text
./tests/test_cli.py:5:1: F401 'typing.List' imported but unused
./tests/test_cli.py:14:54: E741 ambiguous variable name 'l'
./tests/test_cli.py:16:101: E501 line too long (106 > 100 characters)
./tests/test_cli.py:62:101: E501 line too long (143 > 100 characters)
./tests/test_cli.py:88:101: E501 line too long (147 > 100 characters)
./src/pydistcheck/_compat.py:12:5: F401 'tomli as tomllib' imported but unused
```