### PR TITLE
[ci] add isort checks (fixes #28)

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -25,6 +25,7 @@ jobs:
             -c conda-forge \
               black \
               flake8 \
+              isort \
               pylint \
               shellcheck
           make lint

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ clean:
 
 .PHONY: format
 format:
+	isort .
 	black .
 
 .PHONY: full-run

--- a/bin/summarize-sizes.py
+++ b/bin/summarize-sizes.py
@@ -1,4 +1,5 @@
 import sys
+
 import pandas as pd
 
 CSV_FILE = sys.argv[1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 100
 
+[tool.isort]
+line_length = 100
+profile = "black"
+
 [tool.pylint.messages_control]
 
 max-line-length = 100

--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -4,6 +4,7 @@ performs on distributions.
 """
 
 from typing import List
+
 from pydistcheck.distribution_summary import _DistributionSummary
 from pydistcheck.utils import _FileSize
 

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -5,7 +5,9 @@ CLI entrypoints
 import os
 import sys
 from typing import Dict, List, Optional, Union
+
 import click
+
 from pydistcheck._compat import tomllib
 from pydistcheck.checks import (
     _DistroTooLargeCompressedCheck,

--- a/src/pydistcheck/utils.py
+++ b/src/pydistcheck/utils.py
@@ -5,7 +5,6 @@ not specific to package distributions
 
 from typing import Any, Tuple, Union
 
-
 _UNIT_TO_NUM_BYTES = {"B": 1, "K": 1024, "M": 1024**2, "G": 1024**3}
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,9 @@
 import os
 import re
-import pytest
 
+import pytest
 from click.testing import CliRunner, Result
+
 from pydistcheck.cli import check
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")

--- a/tests/test_distribution_summary.py
+++ b/tests/test_distribution_summary.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from pydistcheck.distribution_summary import _DistributionSummary

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pydistcheck.utils import _FileSize
 
 


### PR DESCRIPTION
Fixes #28 .

Enforces `isort` sorting on the project's Python imports.

Uses the `black` profile to prevent `isort` and `black` from overwriting each others' changes: https://pycqa.github.io/isort/docs/configuration/black_compatibility.html.