### PR TITLE
[ci] add mypy checks (fixes #26)

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -27,6 +27,6 @@ jobs:
               flake8 \
               isort \
               'mypy>=0.931' \
-              pylint \
+              'pylint>=2.15.3' \
               shellcheck
           make lint

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -26,6 +26,7 @@ jobs:
               black \
               flake8 \
               isort \
+              mypy \
               pylint \
               shellcheck
           make lint

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -26,7 +26,7 @@ jobs:
               black \
               flake8 \
               isort \
-              mypy \
+              'mypy>=0.931' \
               pylint \
               shellcheck
           make lint

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ lint:
 		--check \
 		.
 	flake8 .
+	mypy .
 	pylint ./src
 
 .PHONY: smoke-tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ line-length = 100
 line_length = 100
 profile = "black"
 
+[tool.mypy]
+exclude = 'docs/conf\.py$'
+ignore_missing_imports = true
+
 [tool.pylint.messages_control]
 
 max-line-length = 100

--- a/src/pydistcheck/__init__.py
+++ b/src/pydistcheck/__init__.py
@@ -1,4 +1,4 @@
 # pylint: disable=missing-module-docstring
 
 # no one should be importing from this package
-__all__ = []
+__all__ = []  # type: ignore

--- a/src/pydistcheck/_compat.py
+++ b/src/pydistcheck/_compat.py
@@ -6,6 +6,6 @@ with a wide range of dependency versions.
 """
 
 try:
-    import tomllib  # noqa: F401
+    import tomllib  # type: ignore  # noqa: F401
 except ModuleNotFoundError:
     import tomli as tomllib  # type: ignore  # noqa: F401

--- a/src/pydistcheck/_compat.py
+++ b/src/pydistcheck/_compat.py
@@ -8,4 +8,4 @@ with a wide range of dependency versions.
 try:
     import tomllib  # noqa: F401
 except ModuleNotFoundError:
-    import tomli as tomllib  # noqa: F401
+    import tomli as tomllib  # type: ignore  # noqa: F401

--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -3,13 +3,18 @@ Implementations for individual checks that ``pydistcheck``
 performs on distributions.
 """
 
-from typing import List
+from typing import List, Protocol
 
 from pydistcheck.distribution_summary import _DistributionSummary
 from pydistcheck.utils import _FileSize
 
 
-class _DistroTooLargeCompressedCheck:
+class _CheckProtocol(Protocol):
+    def __call__(self, distro_summary: _DistributionSummary) -> List[str]:
+        ...
+
+
+class _DistroTooLargeCompressedCheck(_CheckProtocol):
 
     check_name = "distro-too-large-compressed"
 
@@ -29,7 +34,7 @@ class _DistroTooLargeCompressedCheck:
         return out
 
 
-class _DistroTooLargeUnCompressedCheck:
+class _DistroTooLargeUnCompressedCheck(_CheckProtocol):
 
     check_name = "distro-too-large-uncompressed"
 
@@ -49,7 +54,7 @@ class _DistroTooLargeUnCompressedCheck:
         return out
 
 
-class _FileCountCheck:
+class _FileCountCheck(_CheckProtocol):
 
     check_name = "too-many-files"
 

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -14,10 +14,7 @@ from pydistcheck.checks import (
     _DistroTooLargeUnCompressedCheck,
     _FileCountCheck,
 )
-from pydistcheck.distribution_summary import (
-    _DistributionSummary,
-    summarize_distribution_contents,
-)
+from pydistcheck.distribution_summary import _DistributionSummary, summarize_distribution_contents
 from pydistcheck.utils import _FileSize
 
 

--- a/src/pydistcheck/distribution_summary.py
+++ b/src/pydistcheck/distribution_summary.py
@@ -76,7 +76,7 @@ class _DistributionSummary:
 
     @property
     def size_by_file_extension(self) -> defaultdict:
-        out = defaultdict(int)
+        out: defaultdict = defaultdict(int)
         for f in self.file_infos:
             if f.is_file:
                 out[f.file_extension] += f.uncompressed_size_bytes


### PR DESCRIPTION
Fixes #26.

Enforces checks from `mypy`, and addresses all of the warnings raised.

```text
src/pydistcheck/__init__.py:4: error: Need type annotation for "__all__" (hint: "__all__: List[<type>] = ...")
docs/conf.py:16: error: Need type annotation for "extensions" (hint: "extensions: List[<type>] = ...")
bin/summarize-sizes.py:3: error: Skipping analyzing "pandas": module is installed, but missing library stubs or py.typed marker
bin/summarize-sizes.py:3: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
src/pydistcheck/distribution_summary.py:79: error: Need type annotation for "out"
src/pydistcheck/_compat.py:9: error: Cannot find implementation or library stub for module named "tomllib"
src/pydistcheck/_compat.py:11: error: Name "tomllib" already defined (possibly by an import)
src/pydistcheck/cli.py:113: error: "object" not callable
Found 7 errors in 6 files (checked 11 source files)
```