### PR TITLE
add .idea/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ dist/
 *.feather
 *.html
 htmlcov/
+.idea/
 *.js
 *.json
 .mypy_cache/


### PR DESCRIPTION
Jetbrains IDEs like PyCharm, IntelliJ, etc. use a `.idea/` folder at the root of the repository to track IDE settings.

Those settings are personalized by individual developers, and this project shouldn't have strong opinions on them.

This PR prevents checking such files into source control.