### PR TITLE
[ci] exclude typing-only Protocol from code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test:
 	PYTHONPATH=src \
 	pytest \
 		--cov=src/pydistcheck \
-		--cov-fail-under=87 \
+		--cov-fail-under=88 \
 		--cov-report="term" \
 		--cov-report="html:htmlcov" \
 		./tests

--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -10,7 +10,7 @@ from pydistcheck.utils import _FileSize
 
 
 class _CheckProtocol(Protocol):
-    def __call__(self, distro_summary: _DistributionSummary) -> List[str]:
+    def __call__(self, distro_summary: _DistributionSummary) -> List[str]:  # pragma: no cover
         ...
 
 


### PR DESCRIPTION
To convince `mypy` that all check classes in `checks.py` are callable, a `typing.Protocol` was added in #70.

That is kind of like an abstract base class...it defines methods and their signatures, but the actual implementations from there are never run.

This PR tells `pytest-cov` to ignore such lines.