### PR TITLE
print file sizes in descending order

### DIFF
--- a/src/pydistcheck/distribution_summary.py
+++ b/src/pydistcheck/distribution_summary.py
@@ -7,7 +7,7 @@ import os
 import pathlib
 import tarfile
 import zipfile
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
 from typing import List
 
@@ -74,9 +74,21 @@ class _DistributionSummary:
         return sum(f.uncompressed_size_bytes for f in self.file_infos)
 
     @property
-    def size_by_file_extension(self) -> defaultdict:
-        out: defaultdict = defaultdict(int)
+    def size_by_file_extension(self) -> OrderedDict:
+        """
+        Aggregate file sizes in a distribution by extension.
+
+        :return: An OrderedDict where keys are file extensions and values are the total size in
+                 bytes occupied by such files in the distribution. Sorted in descending
+                 order by size.
+        """
+        summary_dict: defaultdict = defaultdict(int)
         for f in self.file_infos:
             if f.is_file:
-                out[f.file_extension] += f.uncompressed_size_bytes
+                summary_dict[f.file_extension] += f.uncompressed_size_bytes
+        sorted_sizes = list(summary_dict.items())
+        sorted_sizes.sort(key=lambda x: x[1], reverse=True)
+        out = OrderedDict()
+        for file_extension, size_in_bytes in sorted_sizes:
+            out[file_extension] = size_in_bytes
         return out

--- a/tests/test_distribution_summary.py
+++ b/tests/test_distribution_summary.py
@@ -31,3 +31,9 @@ def test_distribution_summary_basically_works(distro_file):
 
     # size_by_file_extension should work as expected
     assert ds.size_by_file_extension == {".py": 32, ".txt": 11358}
+
+    # size_by_file_extension should return results sorted from largest to smallest by file size
+    last_size_seen = float("inf")
+    for file_extension, size_in_bytes in ds.size_by_file_extension.items():
+        assert size_in_bytes < last_size_seen
+        last_size_seen = size_in_bytes


### PR DESCRIPTION
Contributes to #79.

Ensures that `pydistcheck --inspect` prints summarized file sizes in descending order by size, so the files that represent the largest portion of the distribution are at the top.

For example,

```shell
pydistcheck \
    --inspect \
    ./tmp-dir/numpy/source/numpy-1.23.4.tar.gz
```

```text
file size
  * compressed size: 10.2317M
  * uncompressed size: 36.7684M
  * compression space saving: 0.722
contents
  * directories: 218
  * files: 2222
size by extension
  * .py - 8950.6K (23.8%)
  * .c - 7840.7K (20.8%)
  * .rst - 3797.4K (10.1%)
  * .js - 3693.1K (9.8%)
  * .png - 3105.0K (8.2%)
  * .s - 2140.5K (5.7%)
  * .csv - 1323.2K (3.5%)
  * .h - 1273.5K (3.4%)
  * .svg - 1245.0K (3.3%)
  * .src - 1031.4K (2.7%)
  * .pyi - 840.1K (2.2%)
  * .json - 692.5K (1.8%)
  * .pyx - 480.6K (1.3%)
  * .cpp - 374.2K (1.0%)
  * .txt - 265.6K (0.7%)
  * .i - 113.3K (0.3%)
  * .pxd - 81.1K (0.2%)
  * .pdf - 63.6K (0.2%)
  * no-extension - 52.4K (0.1%)
  * .inc - 45.3K (0.1%)
  * .cxx - 30.8K (0.1%)
  * .sh - 22.9K (0.1%)
  * .f90 - 20.2K (0.1%)
  * .md - 19.1K (0.1%)
  ...
  * .typed - 0.0K (0.0%)
```