### PR TITLE
use editable installs in local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ full-run:
 
 .PHONY: install
 install:
-	pipx install --force dist/*.tar.gz
+	pipx install --force -e .
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
As of PR, `make install` now uses and editable install with `pipx install -e`.

This should make local development easier, as it means that the package doesn't need to be re-installed to test changes.