### PR TITLE
support checking multiple files in one call (fixes #71)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ full-run:
 
 .PHONY: install
 install:
-	pipx install --force dist/*.tar.gz
+	pipx install -e --force .
 
 .PHONY: lint
 lint:

--- a/bin/full-run.sh
+++ b/bin/full-run.sh
@@ -10,9 +10,7 @@ if [ -d "${OUTPUT_DIR}" ]; then
     exit 1
 else
     echo "creating directory '${OUTPUT_DIR}'"
-    mkdir -p "${OUTPUT_DIR}"
-    mkdir -p "${OUTPUT_DIR}/source"
-    mkdir -p "${OUTPUT_DIR}/wheel"
+    mkdir -p "${OUTPUT_DIR}/distributions"
 fi
 
 ARTIFACTS_CSV="${OUTPUT_DIR}/artifacts.csv"
@@ -39,14 +37,7 @@ else
     bin/download-package.sh \
         "${ARTIFACTS_CSV}" \
         "${SOURCE_FILE}" \
-        "${OUTPUT_DIR}/source"
-
-    pydistcheck \
-      --inspect \
-      --max-allowed-files 2500 \
-      --max-allowed-size-compressed '250M' \
-      --max-allowed-size-uncompressed '250M' \
-      "${OUTPUT_DIR}/source/${SOURCE_FILE}"
+        "${OUTPUT_DIR}/distributions"
 fi
 
 echo "searching for a wheel"
@@ -65,12 +56,13 @@ else
     bin/download-package.sh \
         "${ARTIFACTS_CSV}" \
         "${WHEEL_FILE}" \
-        "${OUTPUT_DIR}/wheel"
-
-    pydistcheck \
-      --inspect \
-      --max-allowed-files 2500 \
-      --max-allowed-size-compressed '250M' \
-      --max-allowed-size-uncompressed '250M' \
-      "${OUTPUT_DIR}/wheel/${WHEEL_FILE}"
+        "${OUTPUT_DIR}/distributions"
 fi
+
+
+pydistcheck \
+  --inspect \
+  --max-allowed-files 2500 \
+  --max-allowed-size-compressed '250M' \
+  --max-allowed-size-uncompressed '250M' \
+  "${OUTPUT_DIR}/distributions"/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,6 @@ max-line-length = 100
 disable = [
   "invalid-name",
   "missing-function-docstring",
-  "too-few-public-methods"
+  "too-few-public-methods",
+  "too-many-locals"
 ]

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -103,22 +103,24 @@ def check(
 
     any_errors_found = False
     for filepath in filepaths_to_check:
+        print(f"checking '{filepath}'")
+
         if inspect:
             inspect_distribution(filepath=filepath)
 
-            summary = _DistributionSummary.from_file(filename=filepath)
-            errors: List[str] = []
-            for this_check in checks:
-                errors += this_check(distro_summary=summary)
+        summary = _DistributionSummary.from_file(filename=filepath)
+        errors: List[str] = []
+        for this_check in checks:
+            errors += this_check(distro_summary=summary)
 
-            for i, error_msg in enumerate(errors):
-                print(f"{i + 1}. {error_msg}")
+        for i, error_msg in enumerate(errors):
+            print(f"{i + 1}. {error_msg}")
 
-            num_errors_for_this_file = len(errors)
-            if num_errors_for_this_file:
-                any_errors_found = True
+        num_errors_for_this_file = len(errors)
+        if num_errors_for_this_file:
+            any_errors_found = True
 
-            print(f"errors found while checking: {num_errors_for_this_file}")
+        print(f"errors found while checking: {num_errors_for_this_file}")
 
     # now that all files have been checked, be sure to exit with a non-0 code
     # if any errors were found

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -21,8 +21,9 @@ from pydistcheck.utils import _FileSize
 
 @click.command()
 @click.argument(
-    "filename",
+    "filepaths",
     type=click.Path(exists=True),
+    nargs=-1,
 )
 @click.option(
     "--inspect",
@@ -64,7 +65,7 @@ from pydistcheck.utils import _FileSize
     ),
 )
 def check(
-    filename: str,
+    filepaths: str,
     inspect: bool,
     max_allowed_files: int,
     max_allowed_size_compressed: str,
@@ -75,7 +76,7 @@ def check(
     errors if those are not met.
     """
     print("running pydistcheck")
-    print(click.format_filename(filename))
+    filepaths_to_check = [click.format_filename(f) for f in filepaths]
 
     tool_options: Dict[str, Union[int, str]] = {}
     if os.path.exists("pyproject.toml"):
@@ -85,9 +86,6 @@ def check(
 
     print("pyproject options")
     print(tool_options)
-
-    if inspect:
-        inspect_distribution(filepath=click.format_filename(filename))
 
     checks = [
         _DistroTooLargeCompressedCheck(
@@ -103,13 +101,25 @@ def check(
         _FileCountCheck(max_allowed_files=max_allowed_files),
     ]
 
-    summary = _DistributionSummary.from_file(filename=click.format_filename(filename))
-    errors: List[str] = []
-    for this_check in checks:
-        errors += this_check(distro_summary=summary)
+    any_errors_found = False
+    for filepath in filepaths_to_check:
+        if inspect:
+            inspect_distribution(filepath=filepath)
 
-    for i, error_msg in enumerate(errors):
-        print(f"{i + 1}. {error_msg}")
+            summary = _DistributionSummary.from_file(filename=filepath)
+            errors: List[str] = []
+            for this_check in checks:
+                errors += this_check(distro_summary=summary)
 
-    print(f"errors found while checking: {len(errors)}")
-    sys.exit(len(errors))
+            for i, error_msg in enumerate(errors):
+                print(f"{i + 1}. {error_msg}")
+
+            num_errors_for_this_file = len(errors)
+            if num_errors_for_this_file:
+                any_errors_found = True
+
+            print(f"errors found while checking: {num_errors_for_this_file}")
+
+    # now that all files have been checked, be sure to exit with a non-0 code
+    # if any errors were found
+    sys.exit(int(any_errors_found))


### PR DESCRIPTION
Fixes #71.

As of this PR, something like the following is now possible:

```shell
pydistcheck dist/*
```

Where `dist/*` contains multiple wheels and/or source distributions.