### PR TITLE
add beginning and end log messages

### DIFF
--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -74,7 +74,7 @@ def check(
     Run the contents of a distribution through a set of checks, and warn about
     any problematic characteristics that are detected.
     """
-    print("running pydistcheck")
+    print("==================== running pydistcheck ====================")
     print(click.format_filename(filename))
 
     tool_options: Dict[str, Union[int, str]] = {}
@@ -112,4 +112,5 @@ def check(
         print(f"{i + 1}. {error_msg}")
 
     print(f"errors found while checking: {len(errors)}")
+    print("==================== done running pydistcheck ===============")
     sys.exit(len(errors))


### PR DESCRIPTION
Adds beginning and end log messages, so it's clear where `pydistcheck`'s output begins and ends.

Like this

```text
==================== running pydistcheck ====================
python-package/dist/lightgbm-3.3.2.99-py3-none-manylinux1_x86_64.whl
pyproject options
{}
1. [too-many-files] Found 16 files. Only 1 allowed.
errors found while checking: 1
==================== done running pydistcheck ===============
```