### PR TITLE
add test on nonexistent file

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,13 @@ def test_check_runs_without_error(distro_file):
     assert result.exit_code == 0
 
 
+def test_check_fails_with_informative_error_if_file_doesnt_exist():
+    runner = CliRunner()
+    result = runner.invoke(check, ["some-garbage.exe"])
+    assert result.exit_code > 0
+    _assert_log_matches_pattern(result, r"Path 'some\-garbage\.exe' does not exist\.$")
+
+
 @pytest.mark.parametrize("distro_file", ["base-package.tar.gz", "base-package.zip"])
 def test_check_respects_max_allowed_files(distro_file):
     runner = CliRunner()


### PR DESCRIPTION
Contributes to #71.

Adds a test checking that an informative error is raised if `pydistcheck` is passed a file that doesn't exist.

This is important because today, the project depends on `click`'s machinery to raise that exception.

https://github.com/jameslamb/pydistcheck/blob/499858c671dd436d0ee36e84e5098e2c4bf60df1/src/pydistcheck/cli.py#L25