### PR TITLE
[docs] add installation and usage docs (fixes #63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # pydistcheck
 
-[![PyPI Version](https://img.shields.io/pypi/v/pydistcheck.svg?logo=pypi&logoColor=white)](https://pypi.org/project/pydistcheck)
-[![PyPI downloads](https://static.pepy.tech/badge/pydistcheck)](https://pypi.org/project/pydistcheck)
 [![Documentation Status](https://readthedocs.org/projects/pydistcheck/badge/?version=latest)](https://pydistcheck.readthedocs.io/)
 [![GitHub Actions](https://github.com/jameslamb/pydistcheck/workflows/unit-tests/badge.svg?branch=main)](https://github.com/jameslamb/pydistcheck/actions/workflows/unit-tests.yml)
 [![GitHub Actions](https://github.com/jameslamb/pydistcheck/workflows/smoke-tests/badge.svg?branch=main)](https://github.com/jameslamb/pydistcheck/actions/workflows/smoke-tests.yml)
+
+[![PyPI version](https://img.shields.io/pypi/v/pydistcheck.svg?logo=pypi&logoColor=white)](https://pypi.org/project/pydistcheck)
+[![PyPI downloads](https://static.pepy.tech/badge/pydistcheck)](https://pypi.org/project/pydistcheck)
+
+[![conda-forge version](https://img.shields.io/conda/vn/conda-forge/pydistcheck.svg)](https://anaconda.org/conda-forge/pydistcheck)
+[![conda-forge downloads](https://img.shields.io/conda/dn/conda-forge/pydistcheck.svg)](https://anaconda.org/conda-forge/pydistcheck)
 
 > **Warning**
 >

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # pydistcheck
 
+[![conda-forge version](https://img.shields.io/conda/vn/conda-forge/pydistcheck.svg)](https://anaconda.org/conda-forge/pydistcheck)
+[![conda-forge downloads](https://img.shields.io/conda/dn/conda-forge/pydistcheck.svg)](https://anaconda.org/conda-forge/pydistcheck)
+[![PyPI Version](https://img.shields.io/pypi/v/pydistcheck.svg?logo=pypi&logoColor=white)](https://pypi.org/project/pydistcheck)
+[![PyPI downloads](https://static.pepy.tech/badge/pydistcheck)](https://pypi.org/project/pydistcheck)
 [![Documentation Status](https://readthedocs.org/projects/pydistcheck/badge/?version=latest)](https://pydistcheck.readthedocs.io/)
 [![GitHub Actions](https://github.com/jameslamb/pydistcheck/workflows/unit-tests/badge.svg?branch=main)](https://github.com/jameslamb/pydistcheck/actions/workflows/unit-tests.yml)
 [![GitHub Actions](https://github.com/jameslamb/pydistcheck/workflows/smoke-tests/badge.svg?branch=main)](https://github.com/jameslamb/pydistcheck/actions/workflows/smoke-tests.yml)
-
-[![PyPI version](https://img.shields.io/pypi/v/pydistcheck.svg?logo=pypi&logoColor=white)](https://pypi.org/project/pydistcheck)
-[![PyPI downloads](https://static.pepy.tech/badge/pydistcheck)](https://pypi.org/project/pydistcheck)
-
-[![conda-forge version](https://img.shields.io/conda/vn/conda-forge/pydistcheck.svg)](https://anaconda.org/conda-forge/pydistcheck)
-[![conda-forge downloads](https://img.shields.io/conda/dn/conda-forge/pydistcheck.svg)](https://anaconda.org/conda-forge/pydistcheck)
 
 > **Warning**
 >

--- a/README.md
+++ b/README.md
@@ -8,10 +8,16 @@
 [![GitHub Actions](https://github.com/jameslamb/pydistcheck/workflows/unit-tests/badge.svg?branch=main)](https://github.com/jameslamb/pydistcheck/actions/workflows/unit-tests.yml)
 [![GitHub Actions](https://github.com/jameslamb/pydistcheck/workflows/smoke-tests/badge.svg?branch=main)](https://github.com/jameslamb/pydistcheck/actions/workflows/smoke-tests.yml)
 
-> **Warning**
->
-> This project is very-very-very new and will change significantly.
-> If I was you, **I wouldn't use it**.
+## What is `pydistcheck`?
+
+`pydistcheck` is a command line interface (CLI) for:
+
+* inspecting the contents of Python package distributions during development
+* enforcing constraints on Python package distributions in continuous integration
+
+It's inspired by R's `R CMD check`.
+
+For more background on the value of such a tool, see the SciPY 2022 talk "Does that CSV Belong on PyPI? Probably Not" ([video link](https://www.youtube.com/watch?v=1a7g5l_g_U8)).
 
 ## Installation
 
@@ -26,7 +32,7 @@ pipx install pydistcheck
 Given a Python distribution...
 
 ```shell
-pydistcheck dist/*.tar.gz
+pydistcheck dist/*
 ```
 
 ## Related Projects

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,22 @@
+# docs
+
+This page describes how to test and develop changes to ``pydistcheck``'s documentation.
+
+## Build Locally
+
+To build the documentation locally, create a ``conda`` environment using [`mamba`](https://github.com/mamba-org/mamba).
+
+```shell
+mamba env create \
+    -n pydistcheck-docs \
+    --file ./env.yml
+```
+
+Activate the environment and generate the documentation.
+
+```shell
+source activate pydistcheck-docs
+make html
+```
+
+Open `_build/html/index.html` in a web browser to view the local copy of the documentation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,16 +1,38 @@
 pydistcheck
 ===========
 
-``pydistcheck`` is a command-line interface (CLI) used to detect problematic characteristics
-in Python package distributions.
+``pydistcheck`` is a command-line interface (CLI) used to perform the following activities on Python package distributions.
 
-It is intended to be used in continuous integration and interactively during development.
+**inspect the distribution's contents during development**
+
+- *how large is the package, compressed and uncompressed?*
+- *how many files does it contain?*
+- *what % of the package is Python files? compiled objects?*
+- *what's the difference between the compressed and uncompressed size?*
+
+**enforce constraints in continuous integration**
+
+- *should not be larger than* ``n`` *MB uncompressed*
+- *should not contain more than* ``x`` *files*
+- *should not contain non-portable filepaths*
+
+.. code-block:: shell
+
+    # install
+    pipx install pydistcheck
+
+    # run checks
+    pydistcheck dist/*
+
+    # run checks and view diagnostic information
+    pydistcheck --inspect dist/*
 
 .. toctree::
    :maxdepth: 1
    :caption: Contents:
 
    Check Reference <check-reference>
+   Installation <installation>
 
 Indices and tables
 ==================

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -28,6 +28,11 @@ If you use tools like ``conda`` or ``mamba`` to manage environments, install ``p
 .. code-block:: shell
 
     conda install -c conda-forge pydistcheck
+
+or
+
+.. code-block:: shell
+
     mamba install pydistcheck
 
 development version

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,42 @@
+Installation
+============
+
+``pydistcheck`` is a command-line interface (CLI) written in Python.
+
+Because of this, the preferred way to install it from PyPI is with ``pipx`` (`docs <https://pypa.github.io/pipx/>`_).
+
+.. code-block:: shell
+
+    pipx install pydistcheck
+
+If that doesn't work for you, see the sections below for other options.
+
+PyPI
+****
+
+If you do not want to use ``pipx`` but want to install from PyPI, install with ``pip``.
+
+.. code-block:: shell
+
+    pip install pydistcheck
+
+conda-forge
+***********
+
+If you use tools like ``conda`` or ``mamba`` to manage environments, install ``pydistcheck`` from conda-forge.
+
+.. code-block:: shell
+
+    conda install -c conda-forge pydistcheck
+    mamba install pydistcheck
+
+development version
+*******************
+
+To install the latest development (not released) version of ``pydistcheck``, clone the repo.
+
+.. code-block:: shell
+
+    git clone https://github.com/jameslamb/pydistcheck.git
+    cd pydistcheck
+    pipx install .


### PR DESCRIPTION
Fixes #63 .

adds...

* ... docs on how to develop the documentation locally
* ... "why `pydistcheck`?" type of information to the README and docs home page
* ... an installation guide page in the docs (including `conda-forge` instructions)
* ... conda-forge version and download badges
