### PR TITLE
[ci] add checks from flake8 plugins

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -25,6 +25,10 @@ jobs:
             -c conda-forge \
               black \
               flake8 \
+              flake8-bugbear \
+              flake8-builtins \
+              flake8-comprehensions \
+              flake8-eradicate \
               isort \
               'mypy>=0.931' \
               'pylint>=2.15.3' \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "pydistcheck"
-copyright = "2022, James Lamb"
+copyright = "2022, James Lamb"  # noqa: A001
 author = "James Lamb"
 
 # -- General configuration ---------------------------------------------------

--- a/src/pydistcheck/utils.py
+++ b/src/pydistcheck/utils.py
@@ -3,12 +3,12 @@ miscellaneous helper classes and functions that are
 not specific to package distributions
 """
 
-from typing import Any, Tuple, Union
+from typing import Any, Tuple
 
 _UNIT_TO_NUM_BYTES = {"B": 1, "K": 1024, "M": 1024**2, "G": 1024**3}
 
 
-def _recommend_size_str(num_bytes: float) -> Tuple[float, str]:
+def _recommend_size_str(num_bytes: int) -> Tuple[float, str]:
     if num_bytes < 512:
         return float(num_bytes), "B"
     if num_bytes <= (0.5 * 1024**2):
@@ -23,8 +23,8 @@ class _FileSize:
         self._unit_str = unit_str
 
     @classmethod
-    def from_number(cls, num: Union[int, float]) -> "_FileSize":
-        num_bytes, unit_str = _recommend_size_str(num_bytes=float(num))
+    def from_number(cls, num: int) -> "_FileSize":
+        num_bytes, unit_str = _recommend_size_str(num_bytes=num)
         return cls(num=num_bytes, unit_str=unit_str)
 
     @classmethod

--- a/tests/test_distribution_summary.py
+++ b/tests/test_distribution_summary.py
@@ -34,6 +34,6 @@ def test_distribution_summary_basically_works(distro_file):
 
     # size_by_file_extension should return results sorted from largest to smallest by file size
     last_size_seen = float("inf")
-    for file_extension, size_in_bytes in ds.size_by_file_extension.items():
+    for _, size_in_bytes in ds.size_by_file_extension.items():
         assert size_in_bytes < last_size_seen
         last_size_seen = size_in_bytes

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,6 +35,6 @@ def test_file_size_from_different_inputs_all_parsed_consistently(file_size):
 
 
 def test_file_size_from_number_switches_unit_str_based_on_size():
-    _FileSize.from_number(1.1) == _FileSize(num=1.1, unit_str="B")
-    _FileSize.from_number(100.01) == _FileSize(num=0.10001, unit_str="K")
-    _FileSize.from_number(3456789) == _FileSize(num=3.456789, unit_str="G")
+    assert _FileSize.from_number(1.1) == _FileSize(num=1.1, unit_str="B")
+    assert _FileSize.from_number(100.01) == _FileSize(num=0.10001, unit_str="K")
+    assert _FileSize.from_number(3456789) == _FileSize(num=3.456789, unit_str="G")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,5 +36,8 @@ def test_file_size_from_different_inputs_all_parsed_consistently(file_size):
 
 def test_file_size_from_number_switches_unit_str_based_on_size():
     assert _FileSize.from_number(1.1) == _FileSize(num=1.1, unit_str="B")
-    assert _FileSize.from_number(100.01) == _FileSize(num=0.10001, unit_str="K")
-    assert _FileSize.from_number(3456789) == _FileSize(num=3.456789, unit_str="G")
+    # fractional bytes don't make sense here, so some rounding happens
+    # e.g., 0.1 KB is technically 102.4 bytes, which gets rounded to 102
+    assert _FileSize.from_number(102) == _FileSize(num=0.1, unit_str="K")
+    # 3.456789 * 10**3 = 3711698926.043136
+    assert _FileSize.from_number(3711698926) == _FileSize(num=3.456789, unit_str="G")


### PR DESCRIPTION
I read this excellent article from @MartinThoma tonight: https://towardsdatascience.com/static-code-analysis-for-python-bdce10b8d287, and learned about some `flake8` plugins I'd never seen before.

This PR enables of few of them in this project's CI:

* `flake8-bugbear`: correctness and efficiency related bugs that the `flake8` maintainers thought were too opinionated to be in `flake8`
* `flake8-builtins`: alert on variable names overriding builtins like `max`
* `flake8-comprehensions`: alert on common inefficient patterns with comprehensions
* `flake8-eradicate`: make sure CI fails on commented-out or unused code

Happy (?) to say this also caught a few bugs! `flake8-bugbear` caught some tests that were actually testing anything 🤩 

```text
./tests/test_distribution_summary.py:37:9: B007 Loop control variable 'file_extension' not used within the loop body. If this is intended, start the name with an underscore.
./tests/test_utils.py:38:5: B015 Result of comparison is not used. This line doesn't doanything. Did you intend to prepend it with assert?
./tests/test_utils.py:39:5: B015 Result of comparison is not used. This line doesn't doanything. Did you intend to prepend it with assert?
./tests/test_utils.py:40:5: B015 Result of comparison is not used. This line doesn't doanything. Did you intend to prepend it with assert?
```