### PR TITLE
[docs] add configuration docs

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -26,4 +26,5 @@ jobs:
       - name: build docs
         shell: bash -l {0}
         run: |
+          pip install .
           make -C ./docs html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,6 +3,8 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "mambaforge-4.10"
+  post_create_environment:
+    - pip install .
 conda:
   environment: docs/env.yml
 formats:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ author = "James Lamb"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = []
+extensions = ["sphinx_click"]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,0 +1,15 @@
+Check Reference
+===============
+
+This page describes how to configure ``pydistcheck``.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+CLI arguments
+*************
+
+.. click:: pydistcheck.cli:check
+  :prog: pydistcheck
+  :nested: none

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,5 +1,5 @@
-Check Reference
-===============
+Configuration
+=============
 
 This page describes how to configure ``pydistcheck``.
 

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -5,4 +5,5 @@ channels:
 dependencies:
   - python=3.10
   - sphinx
+  - "sphinx-click>=4.3.0"
   - "sphinx_rtd_theme>=0.5"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,10 +31,6 @@ pydistcheck
    :maxdepth: 1
    :caption: Contents:
 
-   Check Reference <check-reference>
    Installation <installation>
-
-Indices and tables
-==================
-
-* :ref:`genindex`
+   Configuration <configuration>
+   Check Reference <check-reference>


### PR DESCRIPTION
Contributes to #24 .

Adds a dedicated page in the docs describing how to configure `pyddistcheck`.

Uses [`sphinx-cilck`](https://sphinx-click.readthedocs.io/en/latest/) to automatically generate the main contents of that from the main CLI code in the project.

Also removes the unnecessary "Indices and tables" section in the docs homepage.