### PR TITLE
[docs] fix readthedocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,8 +3,9 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "mambaforge-4.10"
-  post_create_environment:
-    - pip install .
+  jobs:
+    post_create_environment:
+      - pip install .
 conda:
   environment: docs/env.yml
 formats:


### PR DESCRIPTION
#105 had an incorrect readthedocs configuration, resulting in the following build error on that service.

> Problem in your project's configuration. Invalid "build.post_create_environment": .readthedocs.yaml: Invalid configuration option: build.post_create_environment. Make sure the key name is correct.

This fixes it.