### PR TITLE
separate output for different distributions with blank lines

### DIFF
--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -77,7 +77,7 @@ def check(
     Run the contents of a distribution through a set of checks, and warn about
     any problematic characteristics that are detected.
     """
-    print("==================== running pydistcheck ====================")
+    print("\n==================== running pydistcheck ====================")
     filepaths_to_check = [click.format_filename(f) for f in filepaths]
     config = _Config()
     kwargs = {
@@ -112,7 +112,7 @@ def check(
 
     any_errors_found = False
     for filepath in filepaths_to_check:
-        print(f"checking '{filepath}'")
+        print(f"\nchecking '{filepath}'")
 
         if config.inspect:
             inspect_distribution(filepath=filepath)
@@ -131,7 +131,7 @@ def check(
 
         print(f"errors found while checking: {num_errors_for_this_file}")
 
-    print("==================== done running pydistcheck ===============")
+    print("\n==================== done running pydistcheck ===============")
 
     # now that all files have been checked, be sure to exit with a non-0 code
     # if any errors were found

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -77,7 +77,7 @@ def check(
     Run the contents of a distribution through a set of checks, and warn about
     any problematic characteristics that are detected.
     """
-    print("\n==================== running pydistcheck ====================")
+    print("==================== running pydistcheck ====================")
     filepaths_to_check = [click.format_filename(f) for f in filepaths]
     config = _Config()
     kwargs = {


### PR DESCRIPTION
Since #91, it's been possible to run `pydistcheck` over multiple files, like.

```shell
pydistcheck dist/*
```

This PR proposes adding a few blank lines to the output, to visually separate results from different packages.

```shell
pip install .
pydistcheck dist/*
```

```text
==================== running pydistcheck ====================

checking 'tests/data/base-package.tar.gz'
errors found while checking: 0

checking 'tests/data/base-package.zip'
errors found while checking: 0

checking 'tests/data/problematic-package.tar.gz'
1. [files-only-differ-by-case] Found files which differ only by case. Such files are not portable, since some filesystems are case-insensitive. Files: tmp/problematic-package/question.PY,tmp/problematic-package/question.py,tmp/problematic-package/Question.py
2. [path-contains-spaces] File paths with spaces are not portable. Found path with spaces: 'tmp/problematic-package/beep boop.ini'
3. [path-contains-spaces] File paths with spaces are not portable. Found path with spaces: 'tmp/problematic-package/bad code'
4. [path-contains-spaces] File paths with spaces are not portable. Found path with spaces: 'tmp/problematic-package/bad code/ship-it.py'
5. [path-contains-non-ascii-characters] Found file path containing non-ASCII characters: 'tmp/problematic-package/?veryone-loves-python.py'
errors found while checking: 5

checking 'tests/data/problematic-package.zip'
1. [files-only-differ-by-case] Found files which differ only by case. Such files are not portable, since some filesystems are case-insensitive. Files: tmp/problematic-package/question.PY,tmp/problematic-package/question.py,tmp/problematic-package/Question.py
2. [path-contains-spaces] File paths with spaces are not portable. Found path with spaces: 'tmp/problematic-package/beep boop.ini'
3. [path-contains-spaces] File paths with spaces are not portable. Found path with spaces: 'tmp/problematic-package/bad code/'
4. [path-contains-spaces] File paths with spaces are not portable. Found path with spaces: 'tmp/problematic-package/bad code/ship-it.py'
5. [path-contains-non-ascii-characters] Found file path containing non-ASCII characters: 'tmp/problematic-package/???veryone-loves-python.py'
errors found while checking: 5

==================== done running pydistcheck ===============
```