### PR TITLE
add defaults to '--help' docs

### DIFF
--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -37,12 +37,14 @@ from pydistcheck.utils import _FileSize
 @click.option(
     "--max-allowed-files",
     default=_Config.max_allowed_files,
+    show_default=True,
     type=int,
     help="maximum number of files allowed in the distribution",
 )
 @click.option(
     "--max-allowed-size-compressed",
     default=_Config.max_allowed_size_compressed,
+    show_default=True,
     type=str,
     help=(
         "maximum allowed compressed size, a string like '1.5M' indicating"
@@ -56,6 +58,7 @@ from pydistcheck.utils import _FileSize
 @click.option(
     "--max-allowed-size-uncompressed",
     default=_Config.max_allowed_size_uncompressed,
+    show_default=True,
     type=str,
     help=(
         "maximum allowed uncompressed size, a string like '1.5M' indicating"


### PR DESCRIPTION
Adds default values to the output of `pydistcheck --help`.

```text
Options:
  --inspect                       print diagnostic information about the
                                  distribution
  --max-allowed-files INTEGER     maximum number of files allowed in the
                                  distribution  [default: 2000]
  --max-allowed-size-compressed TEXT
                                  maximum allowed compressed size, a string
                                  like '1.5M' indicating '1.5 megabytes'.
                                  Supported units: - B = bytes - K = kilobytes
                                  - M = megabytes - G = gigabytes  [default:
                                  50M]
  --max-allowed-size-uncompressed TEXT
                                  maximum allowed uncompressed size, a string
                                  like '1.5M' indicating '1.5 megabytes'.
                                  Supported units: - B = bytes - K = kilobytes
                                  - M = megabytes - G = gigabytes  [default:
                                  75M]
  --help                          Show this message and exit
```