### PR TITLE
add ability to ignore some checks (fixes #80)

### DIFF
--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -23,6 +23,8 @@ ALL_CHECKS = {
 
 
 class _CheckProtocol(Protocol):
+    check_name: str
+
     def __call__(self, distro_summary: _DistributionSummary) -> List[str]:  # pragma: no cover
         ...
 

--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -9,6 +9,18 @@ from typing import List, Protocol
 from pydistcheck.distribution_summary import _DistributionSummary
 from pydistcheck.utils import _FileSize
 
+# ALL_CHECKS constant is used to validate configuration options like '--ignore' that reference
+# check names. It's a set literal so it doesn't need to be recomputed at runtime, and this project
+# relies on unit tests to ensure that it's updated as the list of checks changes.
+ALL_CHECKS = {
+    "distro-too-large-compressed",
+    "distro-too-large-uncompressed",
+    "too-many-files",
+    "files-only-differ-by-case",
+    "path-contains-non-ascii-characters",
+    "path-contains-spaces",
+}
+
 
 class _CheckProtocol(Protocol):
     def __call__(self, distro_summary: _DistributionSummary) -> List[str]:  # pragma: no cover

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -8,6 +8,7 @@ from typing import List
 import click
 
 from pydistcheck.checks import (
+    ALL_CHECKS,
     _DistroTooLargeCompressedCheck,
     _DistroTooLargeUnCompressedCheck,
     _FileCountCheck,
@@ -108,6 +109,13 @@ def check(  # pylint: disable=too-many-arguments
     config.update_from_dict(input_dict=kwargs_that_differ_from_defaults)
 
     checks_to_ignore = {x for x in ignore.split(",") if x.strip() != ""}
+    unrecognized_checks = checks_to_ignore - ALL_CHECKS
+    if unrecognized_checks:
+        # converting to list + sorting here so outputs are deterministic
+        # (since sets don't guarantee ordering)
+        error_str = ",".join(sorted(list(unrecognized_checks)))
+        print(f"ERROR: found the following unrecognized checks passed via '--ignore': {error_str}")
+        sys.exit(1)
 
     checks = [
         _DistroTooLargeCompressedCheck(

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -108,7 +108,7 @@ def check(  # pylint: disable=too-many-arguments
     config.update_from_toml(toml_file="pyproject.toml")
     config.update_from_dict(input_dict=kwargs_that_differ_from_defaults)
 
-    checks_to_ignore = {x for x in ignore.split(",") if x.strip() != ""}
+    checks_to_ignore = {x for x in config.ignore.split(",") if x.strip() != ""}
     unrecognized_checks = checks_to_ignore - ALL_CHECKS
     if unrecognized_checks:
         # converting to list + sorting here so outputs are deterministic

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -113,7 +113,7 @@ def check(  # pylint: disable=too-many-arguments
     if unrecognized_checks:
         # converting to list + sorting here so outputs are deterministic
         # (since sets don't guarantee ordering)
-        error_str = ",".join(sorted(list(unrecognized_checks)))
+        error_str = ",".join(sorted(unrecognized_checks))
         print(f"ERROR: found the following unrecognized checks passed via '--ignore': {error_str}")
         sys.exit(1)
 

--- a/src/pydistcheck/config.py
+++ b/src/pydistcheck/config.py
@@ -51,5 +51,13 @@ class _Config:
         with open(toml_file, "rb") as f:
             config_dict = tomllib.load(f)
             tool_options = config_dict.get("tool", {}).get("pydistcheck", {})
+
+        # list-like stuff in TOML is expected to be a comma-delimited string when passed as
+        # a command-line argument
+        patch_dict: Dict[str, Any] = {}
+        for k, v in tool_options.items():
+            if isinstance(v, list):
+                patch_dict[k] = ",".join(v)
+        tool_options.update(patch_dict)
         self.update_from_dict(tool_options)
         return self

--- a/src/pydistcheck/config.py
+++ b/src/pydistcheck/config.py
@@ -15,6 +15,7 @@ from pydistcheck._compat import tomllib
 #
 # unit tests confirm that it matches the `_Config` class, so it shouldn't ever drift from that class
 _ALLOWED_CONFIG_VALUES = {
+    "ignore",
     "inspect",
     "max_allowed_files",
     "max_allowed_size_compressed",
@@ -24,6 +25,7 @@ _ALLOWED_CONFIG_VALUES = {
 
 @dataclass
 class _Config:
+    ignore: str = ""
     inspect: bool = False
     max_allowed_files: int = 2000
     max_allowed_size_compressed: str = "50M"

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,15 @@
+import pydistcheck.checks
+
+
+def test_all_checks_constant_contains_names_of_all_checks():
+    check_classes = []
+    for obj_name in dir(pydistcheck.checks):
+        obj = getattr(pydistcheck.checks, obj_name)
+        if hasattr(obj, "check_name") and obj is not pydistcheck.checks._CheckProtocol:
+            check_classes.append(obj.check_name)
+
+    # every check should be in ALL_CHECKS
+    assert set(check_classes) == pydistcheck.checks.ALL_CHECKS
+
+    # check class names should be unique
+    assert len(pydistcheck.checks.ALL_CHECKS) == len(check_classes)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -129,3 +129,14 @@ def test_update_from_toml_works_with_all_config_values(base_config, tmpdir, use_
     assert base_config.max_allowed_files == 8
     assert base_config.max_allowed_size_compressed == "3G"
     assert base_config.max_allowed_size_uncompressed == "4.12G"
+
+
+def test_update_from_toml_converts_lists_to_comma_delimited_string(base_config, tmpdir):
+    temp_file = os.path.join(tmpdir, f"{str(uuid.uuid4())}.toml")
+    with open(temp_file, "w") as f:
+        f.write(
+            "[tool.pylint]\n[tool.pydistcheck]\n"
+            "max_allowed_size_compressed = [\n'2.5G',\n'1.56K',\n'4.236B'\n]\n"
+        )
+    base_config.update_from_toml(toml_file=temp_file)
+    assert base_config.max_allowed_size_compressed == "2.5G,1.56K,4.236B"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,6 +57,7 @@ def test_update_from_dict_works_when_changing_all_values(base_config):
     assert base_config.max_allowed_size_compressed == "1G"
     assert base_config.max_allowed_size_uncompressed == "18K"
     patch_dict = {
+        "ignore": "path-contains-spaces,too-many-files",
         "inspect": True,
         "max_allowed_files": 8,
         "max_allowed_size_compressed": "2G",
@@ -109,6 +110,7 @@ def test_update_from_toml_works_with_underscores_and_hyphens(base_config, tmpdir
 def test_update_from_toml_works_with_all_config_values(base_config, tmpdir, use_hyphens):
     temp_file = os.path.join(tmpdir, f"{str(uuid.uuid4())}.toml")
     patch_dict = {
+        "ignore": "'path-contains-spaces,too-many-files'",
         "inspect": "true",
         "max_allowed_files": 8,
         "max_allowed_size_compressed": "'3G'",


### PR DESCRIPTION
Fixes #80.

Adds the ability to selectively skip checks.

Like this

```shell
pydistcheck \
    --ignore files-only-differ-by-case,path-contains-spaces \
     tests/data/*
```

or this

```toml
# pyproject.toml

[tool.pydistcheck]
ignore =
    files-only-differ-by-case,
    path-contains-spaces
```