### PR TITLE
visually separate inspection and checking results in output

### DIFF
--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -142,8 +142,10 @@ def check(  # pylint: disable=too-many-arguments
         print(f"\nchecking '{filepath}'")
 
         if config.inspect:
+            print("----- package inspection summary -----")
             inspect_distribution(filepath=filepath)
 
+        print("------------ check results -----------")
         summary = _DistributionSummary.from_file(filename=filepath)
         errors: List[str] = []
         for this_check in checks:

--- a/src/pydistcheck/inspect.py
+++ b/src/pydistcheck/inspect.py
@@ -7,8 +7,6 @@ from pydistcheck.utils import _FileSize
 
 
 def inspect_distribution(filepath: str) -> None:
-    print(f"checking file '{filepath}'")
-
     summary = _DistributionSummary.from_file(filename=filepath)
     print("file size")
     compressed_size = _FileSize(summary.compressed_size_bytes, "B")


### PR DESCRIPTION
Adds some `----` lines in output to separate the results from inspection (`pydistcheck --inspect`) and checks.

```shell
pip install .
pydistcheck \
    --ignore=path-contains-spaces \
    --inspect \
    tests/data/*
```

Now prints the following:

```text
==================== running pydistcheck ====================

checking 'tests/data/base-package.tar.gz'
----- package inspection summary -----
file size
  * compressed size: 4.124K
  * uncompressed size: 11.123K
  * compression space saving: 0.629
contents
  * directories: 1
  * files: 3
size by extension
  * .txt - 11.1K (99.7%)
  * .py - 0.0K (0.3%)
------------ check results -----------
errors found while checking: 0

checking 'tests/data/base-package.zip'
----- package inspection summary -----
file size
  * compressed size: 4.6006K
  * uncompressed size: 11.123K
  * compression space saving: 0.586
contents
  * directories: 1
  * files: 3
size by extension
  * .txt - 11.1K (99.7%)
  * .py - 0.0K (0.3%)
------------ check results -----------
errors found while checking: 0

checking 'tests/data/problematic-package.tar.gz'
----- package inspection summary -----
file size
  * compressed size: 4.5117K
  * uncompressed size: 11.5596K
  * compression space saving: 0.61
contents
  * directories: 2
  * files: 9
size by extension
  * .txt - 11.1K (96.0%)
  * .py - 0.4K (3.2%)
  * .PY - 0.1K (0.6%)
  * .ini - 0.0K (0.2%)
------------ check results -----------
1. [files-only-differ-by-case] Found files which differ only by case. Such files are not portable, since some filesystems are case-insensitive. Files: tmp/problematic-package/question.PY,tmp/problematic-package/question.py,tmp/problematic-package/Question.py
2. [path-contains-non-ascii-characters] Found file path containing non-ASCII characters: 'tmp/problematic-package/?veryone-loves-python.py'
errors found while checking: 2

checking 'tests/data/problematic-package.zip'
----- package inspection summary -----
file size
  * compressed size: 6.3779K
  * uncompressed size: 11.5596K
  * compression space saving: 0.448
contents
  * directories: 2
  * files: 9
size by extension
  * .txt - 11.1K (96.0%)
  * .py - 0.4K (3.2%)
  * .PY - 0.1K (0.6%)
  * .ini - 0.0K (0.2%)
------------ check results -----------
1. [files-only-differ-by-case] Found files which differ only by case. Such files are not portable, since some filesystems are case-insensitive. Files: tmp/problematic-package/question.PY,tmp/problematic-package/question.py,tmp/problematic-package/Question.py
2. [path-contains-non-ascii-characters] Found file path containing non-ASCII characters: 'tmp/problematic-package/???veryone-loves-python.py'
errors found while checking: 2

==================== done running pydistcheck ===============
```