### PR TITLE
clarify compression space savings in pydistcheck --inspect

### DIFF
--- a/src/pydistcheck/inspect.py
+++ b/src/pydistcheck/inspect.py
@@ -14,7 +14,7 @@ def inspect_distribution(filepath: str) -> None:
     print(f"  * compressed size: {compressed_size}")
     print(f"  * uncompressed size: {uncompressed_size}")
     space_saving = 1.0 - (compressed_size.total_size_bytes / uncompressed_size.total_size_bytes)
-    print(f"  * compression space saving: {round(space_saving, 3)}")
+    print(f"  * compression space saving: {round(100 * space_saving, 1)}%")
 
     print("contents")
     print(f"  * directories: {summary.num_directories}")


### PR DESCRIPTION
Contributes to #79.

Makes it more obvious that compression space savings as reported by `pydistcheck --inspect` is a percentage.

Before:

```text
----- package inspection summary -----
file size
  * compressed size: 6.3779K
  * uncompressed size: 11.5596K
  * compression space saving: 0.448
```

After:

```text
----- package inspection summary -----
file size
  * compressed size: 6.3779K
  * uncompressed size: 11.5596K
  * compression space saving: 44.8%
````