### PR TITLE
simplify file size strings in logs

### DIFF
--- a/src/pydistcheck/utils.py
+++ b/src/pydistcheck/utils.py
@@ -9,12 +9,14 @@ _UNIT_TO_NUM_BYTES = {"B": 1, "K": 1024, "M": 1024**2, "G": 1024**3}
 
 
 def _recommend_size_str(num_bytes: int) -> Tuple[float, str]:
-    if num_bytes < 512:
+    if num_bytes < int(0.1 * 1024):
         return float(num_bytes), "B"
-    if num_bytes <= (0.5 * 1024**2):
+    if num_bytes <= (0.1 * 1024**2):
         return float(num_bytes) / 1024.0, "K"
+    if num_bytes <= (0.1 * 1024**3):
+        return float(num_bytes) / (1024**2), "M"
 
-    return float(num_bytes) / (1024**2), "M"
+    return float(num_bytes) / (1024**3), "G"
 
 
 class _FileSize:
@@ -55,4 +57,4 @@ class _FileSize:
 
     def __str__(self) -> str:
         num_bytes, unit_str = _recommend_size_str(self.total_size_bytes)
-        return f"{round(num_bytes, 4)}{unit_str}"
+        return f"{round(num_bytes, 1)}{unit_str}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -310,7 +310,7 @@ def test_check_prefers_keyword_args_to_pyrpoject_toml_and_defaults(distro_file, 
         result,
         (
             r"^1\. \[distro\-too\-large\-uncompressed\] Uncompressed size [0-9]+\.[0-9]+K is "
-            r"larger than the allowed size \(123\.0B\)\.$"
+            r"larger than the allowed size \(0\.1K\)\.$"
         ),
     )
     _assert_log_matches_pattern(result, "errors found while checking\\: 1")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,3 +41,22 @@ def test_file_size_from_number_switches_unit_str_based_on_size():
     assert _FileSize.from_number(102) == _FileSize(num=0.1, unit_str="K")
     # 3.456789 * 10**3 = 3711698926.043136
     assert _FileSize.from_number(3711698926) == _FileSize(num=3.456789, unit_str="G")
+
+
+@pytest.mark.parametrize(
+    "file_size,expected_str",
+    [
+        (_FileSize.from_number(110), "0.1K"),
+        (_FileSize.from_number(150), "0.1K"),
+        (_FileSize.from_number(1024), "1.0K"),
+        (_FileSize.from_number(100 * 1024), "100.0K"),
+        (_FileSize.from_number(200 * 1024), "0.2M"),
+        (_FileSize.from_number(1024**2), "1.0M"),
+        (_FileSize.from_number(400 * 1024**2), "0.4G"),
+        (_FileSize.from_number(405 * 1024**2), "0.4G"),
+        (_FileSize.from_number(1024**3), "1.0G"),
+        (_FileSize.from_number(int(7.5 * 1024**3)), "7.5G"),
+    ],
+)
+def test_file_size_string_representation_looks_correct(file_size, expected_str):
+    assert str(file_size) == expected_str


### PR DESCRIPTION
Contributes to #79.

There are a few places where `pydistcheck` needs to turn a file size in number of byes into a human-readable string:

* check warnings for checks like `distro-too-large-compressed`
* total file size and cumulative size by file type in `pydistcheck --inspect`

This PR proposes changes to that "what string should be used to represent this size" logic that I hope will make the tool's logs a bit easier to understand.

```shell
pydistcheck \
    --inspect \
    --max-alllowed-size-compressed=1B \
    tests/data/problematic-package.tar.gz
```

Before:

```text
file size
  * compressed size: 4.5117K
  * uncompressed size: 11.5596K
  * compression space saving: 0.61
size by extension
  * .txt - 11.1K (96.0%)
  * .py - 0.4K (3.2%)
  * .PY - 0.1K (0.6%)
  * .ini - 0.0K (0.2%)
------------ check results -----------
1. [distro-too-large-compressed] Compressed size 4.5117K is larger than the allowed size (1.0B).
```

After:

```text
file size
  * compressed size: 4.5K
  * uncompressed size: 11.6K
  * compression space saving: 0.61
size by extension
  * .txt - 11.1K (96.0%)
  * .py - 0.4K (3.2%)
  * .PY - 0.1K (0.6%)
  * .ini - 0.0K (0.2%)
------------ check results -----------
1. [distro-too-large-compressed] Compressed size 4.5K is larger than the allowed size (1.0B).
```