### PR TITLE
[ci] consolidate references to test data

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,8 @@ from click.testing import CliRunner, Result
 
 from pydistcheck.cli import check
 
+BASE_PACKAGES = ["base-package-0.1.0.tar.gz", "base-package-0.1.0.zip"]
+PROBLEMATIC_PACKAGES = ["problematic-package-0.1.0.tar.gz", "problematic-package-0.1.0.zip"]
 TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 
@@ -20,7 +22,7 @@ def _assert_log_matches_pattern(result: Result, pattern: str, num_times: int = 1
     assert num_matches_found == num_times, msg
 
 
-@pytest.mark.parametrize("distro_file", ["base-package-0.1.0.tar.gz", "base-package-0.1.0.zip"])
+@pytest.mark.parametrize("distro_file", BASE_PACKAGES)
 def test_check_runs_without_error(distro_file):
     runner = CliRunner()
     result = runner.invoke(check, [os.path.join(TEST_DATA_DIR, distro_file)])
@@ -59,7 +61,7 @@ def test_check_runs_for_all_files_before_exiting():
     )
 
 
-@pytest.mark.parametrize("distro_file", ["base-package-0.1.0.tar.gz", "base-package-0.1.0.zip"])
+@pytest.mark.parametrize("distro_file", BASE_PACKAGES)
 def test_check_respects_ignore_with_one_check(distro_file):
     runner = CliRunner()
 
@@ -93,7 +95,7 @@ def test_check_respects_ignore_with_one_check(distro_file):
     _assert_log_matches_pattern(result, "errors found while checking\\: 0")
 
 
-@pytest.mark.parametrize("distro_file", ["base-package-0.1.0.tar.gz", "base-package-0.1.0.zip"])
+@pytest.mark.parametrize("distro_file", BASE_PACKAGES)
 def test_check_respects_ignore_with_multiple_checks(distro_file):
     runner = CliRunner()
 
@@ -140,7 +142,7 @@ def test_check_respects_ignore_with_multiple_checks(distro_file):
     _assert_log_matches_pattern(result, "errors found while checking\\: 0")
 
 
-@pytest.mark.parametrize("distro_file", ["base-package-0.1.0.tar.gz", "base-package-0.1.0.zip"])
+@pytest.mark.parametrize("distro_file", BASE_PACKAGES)
 def test_check_fails_with_expected_error_if_one_check_is_unrecognized(distro_file):
     result = CliRunner().invoke(
         check,
@@ -156,7 +158,7 @@ def test_check_fails_with_expected_error_if_one_check_is_unrecognized(distro_fil
     )
 
 
-@pytest.mark.parametrize("distro_file", ["base-package-0.1.0.tar.gz", "base-package-0.1.0.zip"])
+@pytest.mark.parametrize("distro_file", BASE_PACKAGES)
 def test_check_fails_with_expected_error_if_multiple_checks_are_unrecognized(distro_file):
     result = CliRunner().invoke(
         check,
@@ -175,7 +177,7 @@ def test_check_fails_with_expected_error_if_multiple_checks_are_unrecognized(dis
     )
 
 
-@pytest.mark.parametrize("distro_file", ["base-package-0.1.0.tar.gz", "base-package-0.1.0.zip"])
+@pytest.mark.parametrize("distro_file", BASE_PACKAGES)
 def test_check_respects_max_allowed_files(distro_file):
     runner = CliRunner()
     result = runner.invoke(
@@ -199,7 +201,7 @@ def test_check_respects_max_allowed_files(distro_file):
         "708B",
     ],
 )
-@pytest.mark.parametrize("distro_file", ["base-package-0.1.0.tar.gz", "base-package-0.1.0.zip"])
+@pytest.mark.parametrize("distro_file", BASE_PACKAGES)
 def test_check_respects_max_allowed_size_compressed(size_str, distro_file):
     runner = CliRunner()
     result = runner.invoke(
@@ -228,7 +230,7 @@ def test_check_respects_max_allowed_size_compressed(size_str, distro_file):
         "708B",
     ],
 )
-@pytest.mark.parametrize("distro_file", ["base-package-0.1.0.tar.gz", "base-package-0.1.0.zip"])
+@pytest.mark.parametrize("distro_file", BASE_PACKAGES)
 def test_check_respects_max_allowed_size_uncompressed(size_str, distro_file):
     runner = CliRunner()
     result = runner.invoke(
@@ -247,7 +249,7 @@ def test_check_respects_max_allowed_size_uncompressed(size_str, distro_file):
     _assert_log_matches_pattern(result, "errors found while checking\\: 1")
 
 
-@pytest.mark.parametrize("distro_file", ["base-package-0.1.0.tar.gz", "base-package-0.1.0.zip"])
+@pytest.mark.parametrize("distro_file", BASE_PACKAGES)
 def test_check_prefers_pyproject_toml_to_defaults(distro_file, tmp_path):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
@@ -269,7 +271,7 @@ def test_check_prefers_pyproject_toml_to_defaults(distro_file, tmp_path):
     _assert_log_matches_pattern(result, "errors found while checking\\: 1")
 
 
-@pytest.mark.parametrize("distro_file", ["base-package-0.1.0.tar.gz", "base-package-0.1.0.zip"])
+@pytest.mark.parametrize("distro_file", BASE_PACKAGES)
 def test_check_handles_ignore_list_in_pyproject_toml_correctly(distro_file, tmp_path):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
@@ -294,7 +296,7 @@ def test_check_handles_ignore_list_in_pyproject_toml_correctly(distro_file, tmp_
         _assert_log_matches_pattern(result, "errors found while checking\\: 0")
 
 
-@pytest.mark.parametrize("distro_file", ["base-package-0.1.0.tar.gz", "base-package-0.1.0.zip"])
+@pytest.mark.parametrize("distro_file", BASE_PACKAGES)
 def test_check_prefers_keyword_args_to_pyrpoject_toml_and_defaults(distro_file, tmp_path):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
@@ -316,9 +318,7 @@ def test_check_prefers_keyword_args_to_pyrpoject_toml_and_defaults(distro_file, 
     _assert_log_matches_pattern(result, "errors found while checking\\: 1")
 
 
-@pytest.mark.parametrize(
-    "distro_file", ["problematic-package-0.1.0.tar.gz", "problematic-package-0.1.0.zip"]
-)
+@pytest.mark.parametrize("distro_file", PROBLEMATIC_PACKAGES)
 def test_cli_raises_exactly_the_expected_number_of_errors_for_the_problematic_package(distro_file):
     runner = CliRunner()
     result = runner.invoke(
@@ -329,9 +329,7 @@ def test_cli_raises_exactly_the_expected_number_of_errors_for_the_problematic_pa
     _assert_log_matches_pattern(result=result, pattern=r"errors found while checking\: 6$")
 
 
-@pytest.mark.parametrize(
-    "distro_file", ["problematic-package-0.1.0.tar.gz", "problematic-package-0.1.0.zip"]
-)
+@pytest.mark.parametrize("distro_file", PROBLEMATIC_PACKAGES)
 def test_files_only_differ_by_case_works(distro_file):
     runner = CliRunner()
     result = runner.invoke(
@@ -353,9 +351,7 @@ def test_files_only_differ_by_case_works(distro_file):
     _assert_log_matches_pattern(result=result, pattern=r"errors found while checking\: [0-9]{1}")
 
 
-@pytest.mark.parametrize(
-    "distro_file", ["problematic-package-0.1.0.tar.gz", "problematic-package-0.1.0.zip"]
-)
+@pytest.mark.parametrize("distro_file", PROBLEMATIC_PACKAGES)
 def test_path_contains_spaces_works(distro_file):
     runner = CliRunner()
     result = runner.invoke(
@@ -404,9 +400,7 @@ def test_path_contains_spaces_works(distro_file):
     _assert_log_matches_pattern(result=result, pattern=r"errors found while checking\: [0-9]{1}")
 
 
-@pytest.mark.parametrize(
-    "distro_file", ["problematic-package-0.1.0.tar.gz", "problematic-package-0.1.0.zip"]
-)
+@pytest.mark.parametrize("distro_file", PROBLEMATIC_PACKAGES)
 def test_path_contains_non_ascii_characters_works(distro_file):
     runner = CliRunner()
     result = runner.invoke(
@@ -434,7 +428,7 @@ def test_path_contains_non_ascii_characters_works(distro_file):
 # --------------------- #
 
 
-@pytest.mark.parametrize("distro_file", ["base-package-0.1.0.tar.gz", "base-package-0.1.0.zip"])
+@pytest.mark.parametrize("distro_file", BASE_PACKAGES)
 def test_inspect_runs_before_checks(distro_file):
     runner = CliRunner()
     result = runner.invoke(


### PR DESCRIPTION
Many of the project's unit tests re-use the same set of test distributions, referenced in repeated string literals.

This PR consolidates those into module-level constants, so...

* it's easier to add new test distributions in the future
* there's less risk of new tests not covering all of the distribution types