### PR TITLE
[ci] run smoke tests on Windows

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python_version: 3.8
+            python_version: '3.8'
           - os: windows-latest
-            python_version: 3.10
+            python_version: '3.10'
     steps:
       - name: check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -19,6 +19,8 @@ jobs:
         include:
           - os: ubuntu-latest
             python_version: 3.8
+          - os: windows-latest
+            python_version: 3.10
     steps:
       - name: check out repository
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ lint:
 
 .PHONY: smoke-tests
 smoke-tests:
-	@bin/run-smoke-tests.sh
+	@bash ./bin/run-smoke-tests.sh
 
 .PHONY: test-data
 test-data:


### PR DESCRIPTION
Contributes to #78 .

Runs the smoke tests on Windows, to hopefully catch Windows-specific characteristics of distributions that `pydistcheck` wouldn't otherwise correctly handle.

This is extra important at this moment, when the project's unit tests don't test against wheels (to be added in #124).