### PR TITLE
[ci] switch to alls-good for branch protections

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -22,9 +22,25 @@ jobs:
           - os: windows-latest
             python_version: '3.10'
     steps:
-      - name: fail
+      - name: check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: pydistscheck-tests
+          miniforge-variant: Mambaforge
+          use-mamba: true
+          python-version: ${{ matrix.python_version }}
+      - name: run tests
+        shell: bash -l {0}
         run: |
-          exit 123
+          mamba install \
+            --yes \
+              pipx \
+              requests
+          make install
+          make smoke-tests
   all-smoke-tests-successful:
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -99,9 +99,14 @@ jobs:
         run: |
           bin/check-test-packages.sh ${GITHUB_WORKSPACE}/tests/data
   all-unit-tests-successful:
-    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
+    if: always()
     runs-on: ubuntu-latest
-    needs: [test-cpython, test-pypy, check-test-packages]
+    needs:
+    - test-cpython
+    - test-pypy
+    - check-test-packages
     steps:
-    - name: Note that all tests succeeded
-      run: echo "🎉"
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@v1.2.2
+      with:
+        jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Reverts #132 , #133, #134, #135.

Switches to https://github.com/re-actors/alls-green for enforcing branch protections.