### PR TITLE
[ci] increase smoke test coverage

### DIFF
--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -4,11 +4,10 @@ set -e -u -o pipefail
 
 echo "running smoke tests"
 
-rm -rf ./smoke-tests
-mkdir -p ./smoke-tests
-
 get-files() {
     pkg_name=$1
+    rm -rf ./smoke-tests
+    mkdir ./smoke-tests
     echo ""
     python bin/get-release-files.py \
         "${pkg_name}" \
@@ -17,30 +16,49 @@ get-files() {
 
 # wheel-only package
 get-files catboost
+pydistcheck ./smoke-tests/*
 
 # package where source distro is a .zip
 get-files numpy
+pydistcheck \
+    --max-allowed-files 3000 \
+    --max-allowed-size-uncompressed '150M' \
+    ./smoke-tests/*
 
 # package with so many files that `find -exec du -ch` has to batch results
 get-files tensorflow
+pydistcheck \
+    --max-allowed-files 10000 \
+    --max-allowed-size-compressed '300M' \
+    --max-allowed-size-uncompressed '1G' \
+    ./smoke-tests/*
 
-# package with lots of bundled non-Python code
+# packages with lots of bundled non-Python code
 get-files bokeh
+pydistcheck ./smoke-tests/*
+
 get-files Flask
+pydistcheck ./smoke-tests/*
 
 # package that isn't actually Python code
 get-files cmake
+pydistcheck \
+    --ignore 'path-contains-spaces' \
+    --max-allowed-files 4000 \
+    --max-allowed-size-uncompressed '150M' \
+    ./smoke-tests/*
 
 # Python clients for other systems
 get-files botocore
-get-files kafka-python
-get-files kubernetes
-
 pydistcheck \
-    --ignore 'path-contains-spaces' \
-    --max-allowed-files 8750 \
-    --max-allowed-size-compressed '500M' \
-    --max-allowed-size-uncompressed '1G' \
+    --max-allowed-files 4000 \
+    --max-allowed-size-uncompressed '150M' \
     ./smoke-tests/*
+
+get-files kafka-python
+pydistcheck ./smoke-tests/*
+
+get-files kubernetes
+pydistcheck ./smoke-tests/*
 
 echo "done running smoke tests"


### PR DESCRIPTION
Today, the smoke tests in this project are structured like this:

* download distribution files for many projects into the same directory
* run `pydistcheck ${directory}/*` to check all of them at once

Some of the checked packages raise some warnings with `pydistcheck`'s default values.
To ensure that the smoke tests fail only for runtime errors in `pydistcheck`, some of those defaults are modified.

https://github.com/jameslamb/pydistcheck/blob/aa70dbd3ba2a5c55f39f97afac2e0256e82599cc/bin/run-smoke-tests.sh#L39-L44

This PR proposes switching the approach to running `pydistcheck` once per project in those tests.
This increases the coverage of the tests by:

* avoiding the need to skip checks with `--ignore`
* making it clearer how likely `pydistcheck`'s default values are to result in warnings and a randomly-chosen project from PyPI