### PR TITLE
[docs] add defaults for all options to "Configuration" doc

### DIFF
--- a/docs/_static/defaults.toml
+++ b/docs/_static/defaults.toml
@@ -1,0 +1,7 @@
+[tool.pydistcheck]
+
+ignore = []
+inspect = false
+max_allowed_files = 2000
+max_allowed_size_compressed = '50M'
+max_allowed_size_uncompressed = '75M'

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -29,11 +29,9 @@ pyproject.toml
 
 If a file ``pyproject.toml`` exists in the working directory ``pydistcheck`` is run from, ``pydistcheck`` will look there for configuration.
 
-Put configuration in a ``[tool.pydistcheck]`` section, like the following example.
+Put configuration in a ``[tool.pydistcheck]`` section.
 
-.. code-block:: toml
+The example below contains all of the configuration options for ``pydistcheck``, set to their default values.
 
-    [tool.pydistcheck]
-    inspect = False
-    max_allowed_size_compressed = '1G'
-    max_allowed_size_uncompressed = '4.5G'
+.. literalinclude:: ./_static/defaults.toml
+    :language: toml

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,32 @@
+"""
+Tests that ensure documentation accurately describes the
+state of the project's source code.
+"""
+
+from pathlib import Path
+
+from pydistcheck._compat import tomllib
+from pydistcheck.config import _ALLOWED_CONFIG_VALUES, _Config
+
+DOCS_ROOT = Path(__file__).parents[1].joinpath("docs")
+
+
+def test_default_toml_config():
+    # NOTE: this intentionally does not use pydistcheck._Config.update_from_toml(),
+    #       to ensure that's bugs in that class don't also cause this test to accidentally pass.
+    defaults_example_file = DOCS_ROOT.joinpath("_static/defaults.toml")
+    with open(defaults_example_file, "rb") as f:
+        config_dict = tomllib.load(f)
+        tool_options = config_dict.get("tool", {}).get("pydistcheck", {})
+
+    opts_in_docs = set(tool_options.keys())
+    missing_opts = _ALLOWED_CONFIG_VALUES - opts_in_docs
+    assert len(missing_opts) == 0, f"missing options: {','.join(missing_opts)}"
+    extra_opts = opts_in_docs - _ALLOWED_CONFIG_VALUES
+    assert len(extra_opts) == 0, f"unrecognized options: {','.join(extra_opts)}"
+
+    # values should exactly match the defaults
+    config = _Config().update_from_toml(defaults_example_file)
+    assert (
+        config == _Config()
+    ), "values in 'docs/_static/defaults.toml' do not match actual defaults used by pydistcheck"


### PR DESCRIPTION
Contributes to #55.

Modifies the example `pyproject.toml` content in the docs to contain all configurable options and their default values.

Also adds a unit test confirming that that file matches `pydistcheck`'s actual configuration.

### Benefits of this change

* makes it easier for users to modify `pydistcheck`'s configuration (just copy this file and change what you want)
* adds a bit of extra test coverage of stuff in `pydistcheck.config`
* ensures that the docs evolve as the library does
* allows for clearly documenting longer default values, like the lists of patterns in #55