### PR TITLE
[ci] test that all checks are documented in Check Reference

### DIFF
--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -6,8 +6,8 @@ state of the project's source code.
 from pathlib import Path
 
 from pydistcheck._compat import tomllib
-from pydistcheck.config import _ALLOWED_CONFIG_VALUES, _Config
 from pydistcheck.checks import ALL_CHECKS
+from pydistcheck.config import _ALLOWED_CONFIG_VALUES, _Config
 
 DOCS_ROOT = Path(__file__).parents[1].joinpath("docs")
 
@@ -39,4 +39,6 @@ def test_all_checks_are_documented_in_check_reference():
         check_ref_str = f.read()
 
     for check in ALL_CHECKS:
-        assert f"\n\n{check}\n****" in check_ref_str, f"'{check}' not yet documented in 'docs/check-reference.rst'"
+        assert (
+            f"\n\n{check}\n****" in check_ref_str
+        ), f"'{check}' not yet documented in 'docs/check-reference.rst'"

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from pydistcheck._compat import tomllib
 from pydistcheck.config import _ALLOWED_CONFIG_VALUES, _Config
+from pydistcheck.checks import ALL_CHECKS
 
 DOCS_ROOT = Path(__file__).parents[1].joinpath("docs")
 
@@ -30,3 +31,12 @@ def test_default_toml_config():
     assert (
         config == _Config()
     ), "values in 'docs/_static/defaults.toml' do not match actual defaults used by pydistcheck"
+
+
+def test_all_checks_are_documented_in_check_reference():
+    check_ref_file = DOCS_ROOT.joinpath("check-reference.rst")
+    with open(check_ref_file, "r") as f:
+        check_ref_str = f.read()
+
+    for check in ALL_CHECKS:
+        assert f"\n\n{check}\n****" in check_ref_str, f"'{check}' not yet documented in 'docs/check-reference.rst'"


### PR DESCRIPTION
Contributes to #55.

All checks that `pydistcheck` runs are documented at https://pydistcheck.readthedocs.io/en/latest/check-reference.html.

<img width="1133" alt="image" src="https://user-images.githubusercontent.com/7608904/209766739-6947347f-bd81-4fde-ad6b-7ae1e9c3f318.png">

When `pydistcheck` raises an error like

> [some-check] Found a problem etc. etc.

it's expected that users will be able to go to that page and fine a corresponding `some-check` section providing more details on why `pydistcheck` is warning about that and how to resolve it.

This PR proposes adding a unit test to prevent new checks from being added without that doc also being updated.
I hope this will reduce the risk of the documentation and code drifting too far apart.