### PR TITLE
[ci] simplify create-data-bdist script

### DIFF
--- a/bin/create-test-data-bdist.sh
+++ b/bin/create-test-data-bdist.sh
@@ -40,18 +40,15 @@ pushd tests/data/baseballmetrics
     if [[ $OS_NAME == "linux" ]]; then
       echo "building linux wheels"
       build_linux_wheel 'cp311-cp311'
-      mv \
-          ./dist/baseballmetrics-0.1.0-py3-none-manylinux_*.whl \
-          ../
     elif [[ $OS_NAME == "macos" ]]; then
       echo "building macOS wheels"
       pip wheel -w ./dist .
       mv \
         ./dist/baseballmetrics-0.1.0-py3-none-macosx_*.whl \
         ./dist/baseballmetrics-0.1.0-py3-none-macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_5_x86_64.whl
-      mv \
-        ./dist/baseballmetrics-0.1.0-py3-none-macosx_*.whl \
-        ../
     fi
+    mv \
+        ./dist/*.whl \
+        ../
     echo "done building wheels"
 popd


### PR DESCRIPTION
Contributes to #54.

Simplifies `create-data-bdist` script by removing a bit of duplication and unnecessary specificity in the wheel tags.