### PR TITLE
use black 23.x

### DIFF
--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -32,7 +32,6 @@ class _CheckProtocol(Protocol):
 
 
 class _DistroTooLargeCompressedCheck(_CheckProtocol):
-
     check_name = "distro-too-large-compressed"
 
     def __init__(self, max_allowed_size_bytes: int):
@@ -52,7 +51,6 @@ class _DistroTooLargeCompressedCheck(_CheckProtocol):
 
 
 class _DistroTooLargeUnCompressedCheck(_CheckProtocol):
-
     check_name = "distro-too-large-uncompressed"
 
     def __init__(self, max_allowed_size_bytes: int):
@@ -72,7 +70,6 @@ class _DistroTooLargeUnCompressedCheck(_CheckProtocol):
 
 
 class _FileCountCheck(_CheckProtocol):
-
     check_name = "too-many-files"
 
     def __init__(self, max_allowed_files: int):
@@ -91,7 +88,6 @@ class _FileCountCheck(_CheckProtocol):
 
 
 class _FilesOnlyDifferByCaseCheck(_CheckProtocol):
-
     check_name = "files-only-differ-by-case"
 
     def __call__(self, distro_summary: _DistributionSummary) -> List[str]:
@@ -117,7 +113,6 @@ class _FilesOnlyDifferByCaseCheck(_CheckProtocol):
 
 
 class _NonAsciiCharacterCheck(_CheckProtocol):
-
     check_name = "path-contains-non-ascii-characters"
 
     def __call__(self, distro_summary: _DistributionSummary) -> List[str]:
@@ -134,7 +129,6 @@ class _NonAsciiCharacterCheck(_CheckProtocol):
 
 
 class _SpacesInPathCheck(_CheckProtocol):
-
     check_name = "path-contains-spaces"
 
     def __call__(self, distro_summary: _DistributionSummary) -> List[str]:
@@ -150,7 +144,6 @@ class _SpacesInPathCheck(_CheckProtocol):
 
 
 class _UnexpectedFilesCheck(_CheckProtocol):
-
     check_name = "unexpected-files"
 
     def __init__(

--- a/src/pydistcheck/config.py
+++ b/src/pydistcheck/config.py
@@ -77,7 +77,6 @@ class _Config:
         return self
 
     def update_from_toml(self, toml_file: str) -> "_Config":
-
         if not os.path.exists(toml_file):
             return self
 


### PR DESCRIPTION
`black` 23.x was released recently.

This PR makes `pydistcheck` compliant with it.