### PR TITLE
[ci] check dists

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -61,6 +61,10 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y \
             llvm
+      - name: Install extra tools on Windows
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          choco install zip
       - name: build and check dists
         shell: bash -l {0}
         run: |
@@ -98,10 +102,6 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y \
             llvm
-      - name: Install extra tools on Windows
-        if: startsWith(matrix.os, 'windows')
-        run: |
-          choco install zip
       - name: build and check dists
         shell: bash -l {0}
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -98,6 +98,10 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y \
             llvm
+      - name: Install extra tools on Windows
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          choco install zip
       - name: build and check dists
         shell: bash -l {0}
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -61,12 +61,18 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y \
             llvm
-      - name: run tests
+      - name: build and check dists
         shell: bash -l {0}
         run: |
           pip install -r ./requirements-tests.txt
-          make build
+          make build check-dists
+      - name: install
+        shell: bash -l {0}
+        run: |
           pip install dist/*.whl
+      - name: test
+        shell: bash -l {0}
+        run: |
           make test
   test-pypy:
     name: unit-tests (${{ matrix.os }}, Python-PyPy ${{ matrix.python_version }})
@@ -92,12 +98,18 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y \
             llvm
-      - name: run tests
+      - name: build and check dists
         shell: bash -l {0}
         run: |
           pip install -r ./requirements-tests.txt
-          make build
+          make build check-dists
+      - name: install
+        shell: bash -l {0}
+        run: |
           pip install dist/*.whl
+      - name: test
+        shell: bash -l {0}
+        run: |
           make test
   check-test-packages:
     name: check-test-packages (${{ matrix.os }}, Python ${{ matrix.python_version }})

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,14 @@ check-test-packages:
 		-it python:3.11 \
 		./check-test-packages.sh /opt/test-packages
 
+.PHONY: check-wheels
+check-dists:
+	gunzip -t dist/*.tar.gz
+	zip -T dist/*.whl
+	check-wheel-contents dist/*.whl
+	pyroma --min=10 dist/*.tar.gz
+	twine check --strict dist/*
+
 .PHONY: clean
 clean:
 	rm -rf ./tmp-dir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,11 @@ classifiers = [
     "Topic :: Utilities"
 ]
 description = "Inspect Python package distributions and raise warnings on common problems."
+keywords = [
+    "linter",
+    "python-packaging",
+    "testing"
+]
 license = {file = "LICENSE"}
 maintainers = [
   {name = "James Lamb", email = "jaylamb20@gmail.com"}
@@ -43,7 +48,6 @@ changelog = "https://github.com/jameslamb/pydistcheck/releases"
 requires = [
     "setuptools>=63",
 ]
-
 build-backend = "setuptools.build_meta"
 
 [tool.black]
@@ -60,7 +64,6 @@ ignore_missing_imports = true
 [tool.pylint.messages_control]
 
 max-line-length = 100
-
 disable = [
   "invalid-name",
   "line-too-long",

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,5 @@
 check-wheel-contents
+pyroma
 pytest
 pytest-cov
 requests

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,6 @@
+check-wheel-contents
 pytest
 pytest-cov
 requests
+twine
 types-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-click
-tomli ; python_version < '3.11'


### PR DESCRIPTION
Contributes to #146.

* adds checks in CI that distributions (sdists and wheels) are well-formed
    - `gunzip -t` = "are the sdists valid tar.gz files?"
    - `unzip -T` = "are the wheels valid zip files?"
    - `twin check` = "is the package README (which'll become the PyPI homepage) well-formed?"
    - `pyroma` = "do the sdists have useful, descriptive metadata? are they free from some common misconfiguration issues?"
    - `check-wheel-contents` = "are the wheels free from some common sources of unnecessary files? do their internal files structures follow standard Python library patterns?"
* removes unnecessary `requirements.txt` file