### PR TITLE
simplify error messages

### DIFF
--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -126,7 +126,6 @@ class _FilesOnlyDifferByCaseCheck(_CheckProtocol):
             duplicates_str = ",".join(sorted(duplicates_list))
             msg = (
                 f"[{self.check_name}] Found files which differ only by case. "
-                "Such files are not portable, since some filesystems are case-insensitive. "
                 f"Files: {duplicates_str}"
             )
             out.append(msg)
@@ -156,10 +155,7 @@ class _SpacesInPathCheck(_CheckProtocol):
         out: List[str] = []
         for file_path in distro_summary.all_paths:
             if file_path != file_path.replace(" ", ""):
-                msg = (
-                    f"[{self.check_name}] File paths with spaces are not portable. "
-                    f"Found path with spaces: '{file_path}'"
-                )
+                msg = f"[{self.check_name}] Found path with spaces: '{file_path}'"
                 out.append(msg)
         return out
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -353,7 +353,6 @@ def test_files_only_differ_by_case_works(distro_file):
         result=result,
         pattern=(
             r"^1\. \[files\-only\-differ\-by\-case\] Found files which differ only by case\. "
-            r"Such files are not portable, since some filesystems are case-insensitive\. "
             r"Files\: problematic\-package\-0\.1\.0/problematic_package/Question\.py"
             r",problematic\-package\-0\.1\.0/problematic_package/question\.PY"
             r",problematic\-package\-0\.1\.0/problematic_package/question\.py"
@@ -375,7 +374,7 @@ def test_path_contains_spaces_works(distro_file):
     _assert_log_matches_pattern(
         result=result,
         pattern=(
-            r"^3\. \[path\-contains\-spaces\] File paths with spaces are not portable\. "
+            r"^3\. \[path\-contains\-spaces\] "
             r"Found path with spaces\: 'problematic\-package\-0\.1\.0/beep boop\.ini"
         ),
     )
@@ -384,8 +383,7 @@ def test_path_contains_spaces_works(distro_file):
     _assert_log_matches_pattern(
         result=result,
         pattern=(
-            r"^4\. \[path\-contains\-spaces\] File paths with spaces are not portable\. "
-            r"Found path with spaces\: "
+            r"^4\. \[path\-contains\-spaces\] Found path with spaces\: "
             r"'problematic\-package\-0\.1\.0/problematic_package/bad code[/]*"
         ),
     )
@@ -394,16 +392,14 @@ def test_path_contains_spaces_works(distro_file):
     _assert_log_matches_pattern(
         result=result,
         pattern=(
-            r"^5\. \[path\-contains\-spaces\] File paths with spaces are not portable\. "
-            r"Found path with spaces\: "
+            r"^5\. \[path\-contains\-spaces\] Found path with spaces\: "
             r"'problematic\-package\-0\.1\.0/problematic_package/bad code/__init__\.py"
         ),
     )
     _assert_log_matches_pattern(
         result=result,
         pattern=(
-            r"^6\. \[path\-contains\-spaces\] File paths with spaces are not portable\. "
-            r"Found path with spaces\: "
+            r"^6\. \[path\-contains\-spaces\] Found path with spaces\: "
             r"'problematic\-package\-0\.1\.0/problematic_package/bad code/ship\-it\.py"
         ),
     )


### PR DESCRIPTION
Text like "this is not portable" in error messages isn't necessary, given that `pydistcheck` prints error messages with error IDs that map to details descriptions at https://pydistcheck.readthedocs.io/en/latest/check-reference.html.