### PR TITLE
[ci] check more projects in smoke tests

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
     - main
+  # run every Wednesday at midnight UTC
+  schedule:
+    - cron: '0 0 * * 3'
 
 jobs:
   test:

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -90,7 +90,9 @@ pydistcheck \
     ./smoke-tests/*
 
 get-files gensim
-pydistcheck ./smoke-tests/*
+pydistcheck \
+    --ignore 'compiled-objects-have-debug-symbols' \
+    ./smoke-tests/*
 
 get-files opencv-python
 pydistcheck \
@@ -101,7 +103,9 @@ pydistcheck \
     ./smoke-tests/*
 
 get-files pandas
-pydistcheck ./smoke-tests/*
+pydistcheck \
+    --ignore 'compiled-objects-have-debug-symbols' \
+    ./smoke-tests/*
 
 get-files Pillow
 pydistcheck \
@@ -124,6 +128,8 @@ pydistcheck \
     ./smoke-tests/*
 
 get-files spacy
-pydistcheck ./smoke-tests/*
+pydistcheck \
+    --ignore 'compiled-objects-have-debug-symbols' \
+    ./smoke-tests/*
 
 echo "done running smoke tests"

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -73,4 +73,57 @@ pydistcheck ./smoke-tests/*
 get-files kubernetes
 pydistcheck ./smoke-tests/*
 
+# other complex projects that do custom packaging stuff
+get-files apache-airflow
+pydistcheck ./smoke-tests/*
+
+get-files astropy
+pydistcheck \
+    --ignore 'compiled-objects-have-debug-symbols,unexpected-files' \
+    ./smoke-tests/*
+
+get-files datatable
+pydistcheck \
+    --ignore 'compiled-objects-have-debug-symbols' \
+    --max-allowed-size-compressed '100M' \
+    --max-allowed-size-uncompressed '100M' \
+    ./smoke-tests/*
+
+get-files gensim
+pydistcheck ./smoke-tests/*
+
+get-files opencv-python
+pydistcheck \
+    --ignore 'compiled-objects-have-debug-symbols,unexpected-files' \
+    --max-allowed-files 7200 \
+    --max-allowed-size-compressed '90M' \
+    --max-allowed-size-uncompressed '200M' \
+    ./smoke-tests/*
+
+get-files pandas
+pydistcheck ./smoke-tests/*
+
+get-files Pillow
+pydistcheck \
+    --ignore 'compiled-objects-have-debug-symbols' \
+    ./smoke-tests/*
+
+get-files pytest
+pydistcheck \
+    --ignore 'unexpected-files' \
+    ./smoke-tests/*
+
+get-files scikit-learn
+pydistcheck \
+    --ignore 'compiled-objects-have-debug-symbols,unexpected-files' \
+    ./smoke-tests/*
+
+get-files Shapely
+pydistcheck \
+    --ignore 'compiled-objects-have-debug-symbols' \
+    ./smoke-tests/*
+
+get-files spacy
+pydistcheck ./smoke-tests/*
+
 echo "done running smoke tests"


### PR DESCRIPTION
Adds more projects to the smoke tests, and adds a trigger to run the smoke tests once a week (regardless of activity in this repo).

Taken together, these changes are intended to:

* help expose issues in `pydistcheck`
* detect more portability issues in popular scientific Python projects (and therefore identify opportunities for contributions)