### PR TITLE
support Python 3.7

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
           # Linux #
           #########
           - os: ubuntu-latest
-            python_version: '3.8'
+            python_version: '3.7'
           - os: ubuntu-latest
             python_version: '3.9'
           - os: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -31,7 +32,7 @@ maintainers = [
 ]
 name = "pydistcheck"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 version = "0.3.0.99"
 
 [project.scripts]


### PR DESCRIPTION
Moves the `python-requires` floor on this project down to `>= 3.7`.