### PR TITLE
stop publlishing sdists (fixes #162)

### DIFF
--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -24,19 +24,8 @@ jobs:
         with:
           path: dist/*.whl
 
-  build_sdist:
-    name: Build source distribution
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Build sdist
-        run: pipx run build --sdist
-      - uses: actions/upload-artifact@v3
-        with:
-          path: dist/*.tar.gz
-
   upload_pypi:
-    needs: [build_wheels, build_sdist]
+    needs: [build_wheels]
     runs-on: ubuntu-latest
     # publish whenever a GitHub release is published
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build
 build:
 	rm -r ./dist || true
-	pipx run build --sdist --wheel
+	pipx run build --wheel
 
 .PHONY: check-test-packages
 check-test-packages:
@@ -15,10 +15,8 @@ check-test-packages:
 
 .PHONY: check-wheels
 check-dists:
-	gunzip -t dist/*.tar.gz
 	zip -T dist/*.whl
 	check-wheel-contents dist/*.whl
-	pyroma --min=10 dist/*.tar.gz
 	twine check --strict dist/*
 
 .PHONY: clean


### PR DESCRIPTION
Fixes #162.

This is a pure-Python project supporting a wide range of Python versions, so I don't think there's any value in uploading both source distributions and wheels.

`pip install pydistcheck` should be able install `pydistcheck-{version}-py3-none-any.whl` on a very wide range of platforms.

### benefits of this change

Slightly faster builds and releases in this repo.

A bit less surface area for packaging issues (and therefore maintenance burden).

A bit less storage and data transfer for PyPI.