### PR TITLE
remove unnecessary MANIFEST.in lines

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,1 @@
-include LICENSE
-recursive-include LICENSES *
-include README.md
+graft LICENSES


### PR DESCRIPTION
Minor simplifications to `MANIFEST.in`.
* explicitly `include`-ing `README.md` isn't necessary because `MANIFEST.in` processing automatically does that ([docs](https://packaging.python.org/en/latest/guides/using-manifest-in/))
* explicitly `include`-ing `LICENSE` isn't necessary since it's mentioned in `pyproject.toml`

https://github.com/jameslamb/pydistcheck/blob/c10a5f58d5a9bf58620a30421ebc64b1e970285e/pyproject.toml#L28

* `graft` is a bit more appropriate than `recursive-include` for "include everything in this directory"
