### PR TITLE
[ci] fix catboost checks in smoke tests

### DIFF
--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -17,9 +17,9 @@ get-files() {
 # wheel-only packages
 get-files catboost
 pydistcheck \
-    --ignore 'compiled-objects-have-debug-symbols' \
+    --ignore 'compiled-objects-have-debug-symbols,mixed-file-extensions,too-many-files,unexpected-files' \
     --max-allowed-size-compressed '100M' \
-    --max-allowed-size-uncompressed '215M' \
+    --max-allowed-size-uncompressed '0.5G' \
     ./smoke-tests/*
 
 get-files psycopg2-binary


### PR DESCRIPTION
`catboost` 1.2 was released yesterday, and contained some packaging changes that triggered more checks in this project's smoke tests.

```text
checking './smoke-tests/catboost-1.2-cp310-cp310-macosx_11_0_universal2.whl'
------------ check results -----------
errors found while checking: 0

checking './smoke-tests/catboost-1.2-cp310-cp310-manylinux2014_aarch64.whl'
------------ check results -----------
1. [distro-too-large-uncompressed] Uncompressed size 0.3G is larger than the allowed size (0.2G).
errors found while checking: 1

checking './smoke-tests/catboost-1.2-cp310-cp310-win_amd64.whl'
------------ check results -----------
1. [distro-too-large-uncompressed] Uncompressed size 0.3G is larger than the allowed size (0.2G).
errors found while checking: 1

checking './smoke-tests/catboost-1.2.tar.gz'
------------ check results -----------
1. [distro-too-large-uncompressed] Uncompressed size 0.4G is larger than the allowed size (0.2G).
2. [mixed-file-extensions] Found a mix of file extensions for the same file type: .TXT (15), .txt (4948)
3. [mixed-file-extensions] Found a mix of file extensions for the same file type: .cc (570), .cpp (2219)
4. [too-many-files] Found 44[103](https://github.com/jameslamb/pydistcheck/actions/runs/4866937084/jobs/8678986271#step:5:104) files. Only 2000 allowed.
5. [unexpected-files] Found unexpected file 'catboost-1.2/catboost_all_src/catboost/python-package/catboost/widget/ipython/.gitignore'.
6. [unexpected-files] Found unexpected file 'catboost-1.2/catboost_all_src/contrib/python/numpy/py3/numpy/random/.gitignore'.
errors found while checking: 6

==================== done running pydistcheck ===============
```

https://github.com/jameslamb/pydistcheck/actions/runs/4866937084/jobs/8678986271

This PR fixes that.