### PR TITLE
support specifying an exact config location (fixes #171)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 It's inspired by R's `R CMD check`.
 
-See ["How to Test a Python Distribution"](https://pydistcheck.readthedocs.io/en/latest/how-to-test-a-python-distribution.html) to see how it and simmilar tools like [`auditwheel`](https://github.com/pypa/auditwheel), [`check-wheel-contents`](https://github.com/jwodder/check-wheel-contents), and [`twine check`](https://twine.readthedocs.io/en/stable/#twine-check) fit into Python development workflows.
+See ["How to Test a Python Distribution"](https://pydistcheck.readthedocs.io/en/latest/how-to-test-a-python-distribution.html) to see how it and similar tools like [`auditwheel`](https://github.com/pypa/auditwheel), [`check-wheel-contents`](https://github.com/jwodder/check-wheel-contents), and [`twine check`](https://twine.readthedocs.io/en/stable/#twine-check) fit into Python development workflows.
 
 For more background on the value of such a tool, see the SciPy 2022 talk "Does that CSV Belong on PyPI? Probably Not" ([video link](https://www.youtube.com/watch?v=1a7g5l_g_U8)).
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -29,6 +29,8 @@ pyproject.toml
 
 If a file ``pyproject.toml`` exists in the working directory ``pydistcheck`` is run from, ``pydistcheck`` will look there for configuration.
 
+Alternatively, a path to a TOML file can be provided via CLI argument ``--config``.
+
 Put configuration in a ``[tool.pydistcheck]`` section.
 
 The example below contains all of the configuration options for ``pydistcheck``, set to their default values.


### PR DESCRIPTION
Fixes #171.

By default, `pydistcheck` looks for configuration in a `pyproject.toml` in the working directory it's called from.

This adds the ability to override that behavior and point to a specific TOML file via a command-line argument.

I chose to name that argument `--config`, for consistency with `check-wheel-contents`, `flake8`, `pydocstyle`, and `ruff`.