### PR TITLE
[PEP 631] move dependencies into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,10 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: Utilities"
 ]
+dependencies = [
+    "click",
+    "tomli ; python_version < '3.11'"
+]
 description = "Inspect Python package distributions and raise warnings on common problems."
 keywords = [
     "linter",

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,6 @@ max-line-length = 100
 
 [options]
 packages = find:
-python_requires = >=3.8
-install_requires =
-    click
-    tomli ; python_version < '3.11'
 # ensure that ony files in src/ get included
 package_dir =
     =src


### PR DESCRIPTION
Continuation of #156.

* moves dependencies out of `setup.cfg` and into `pyproject.toml`
* removes `python_requires` in `setup.cfg`, which is redundant with the one in `pyproject.toml`

https://github.com/jameslamb/pydistcheck/blob/f6b8027f44472461b1037fc0db98a988ac66144b/pyproject.toml#L34

### References

Specifying dependencies via the `[options]` table in `setup.cfg` is deprecated in the `setuptools.build_meta` build backend (see e.g. https://github.com/pypa/setuptools/issues/3300).

As a result of PEP 621/ PEP 631, see https://peps.python.org/pep-0631/.

I actually stumbled over something similar recently in LightGBM: https://github.com/microsoft/LightGBM/pull/5942.