### PR TITLE
simplify internal imports and related packaging config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ lint:
 	black \
 		--check \
 		.
-	flake8 .
+	flake8 --max-line-length=100 .
 	mypy .
 	pylint ./src
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,14 +2,7 @@
 max-line-length = 100
 
 [options]
-packages = find:
 python_requires = >=3.8
 install_requires =
     click
     tomli ; python_version < '3.11'
-# ensure that ony files in src/ get included
-package_dir =
-    =src
-
-[options.packages.find]
-where = src

--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -7,9 +7,9 @@ from collections import defaultdict
 from fnmatch import fnmatchcase
 from typing import List, Protocol
 
-from pydistcheck.distribution_summary import _DistributionSummary
-from pydistcheck.shared_lib_utils import _archive_member_has_debug_symbols
-from pydistcheck.utils import _FileSize
+from .distribution_summary import _DistributionSummary
+from .shared_lib_utils import _archive_member_has_debug_symbols
+from .utils import _FileSize
 
 # ALL_CHECKS constant is used to validate configuration options like '--ignore' that reference
 # check names. It's a set literal so it doesn't need to be recomputed at runtime, and this project

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -8,7 +8,8 @@ from typing import List
 import click
 
 from pydistcheck import __version__ as _VERSION
-from pydistcheck.checks import (
+
+from .checks import (
     ALL_CHECKS,
     _CompiledObjectsDebugSymbolCheck,
     _DistroTooLargeCompressedCheck,
@@ -20,10 +21,10 @@ from pydistcheck.checks import (
     _SpacesInPathCheck,
     _UnexpectedFilesCheck,
 )
-from pydistcheck.config import _Config
-from pydistcheck.distribution_summary import _DistributionSummary
-from pydistcheck.inspect import inspect_distribution
-from pydistcheck.utils import _FileSize
+from .config import _Config
+from .distribution_summary import _DistributionSummary
+from .inspect import inspect_distribution
+from .utils import _FileSize
 
 
 @click.command()

--- a/src/pydistcheck/config.py
+++ b/src/pydistcheck/config.py
@@ -8,7 +8,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, Dict
 
-from pydistcheck._compat import tomllib
+from ._compat import tomllib
 
 # putting this in a module-level set to save on the cost of re-computing it inside methods
 # in `_Config` that validate configuration.

--- a/src/pydistcheck/inspect.py
+++ b/src/pydistcheck/inspect.py
@@ -2,8 +2,8 @@
 Code that prints diagnostic information about a distribution.
 """
 
-from pydistcheck.distribution_summary import _DistributionSummary
-from pydistcheck.utils import _FileSize
+from .distribution_summary import _DistributionSummary
+from .utils import _FileSize
 
 
 def inspect_distribution(filepath: str) -> None:

--- a/src/pydistcheck/shared_lib_utils.py
+++ b/src/pydistcheck/shared_lib_utils.py
@@ -9,7 +9,7 @@ import zipfile
 from tempfile import TemporaryDirectory
 from typing import List, Tuple
 
-from pydistcheck.distribution_summary import _FileInfo
+from .distribution_summary import _FileInfo
 
 _COMMAND_FAILED = "__command_failed__"
 _NO_DEBUG_SYMBOLS = "__no_debug_symbols_found__"


### PR DESCRIPTION
This project's `setup.cfg` contains some configuration to achieve the same effect as invoking `setuptools.find_packages()` in a `setup.py`.

https://github.com/jameslamb/pydistcheck/blob/f6b8027f44472461b1037fc0db98a988ac66144b/setup.cfg#L4-L5

https://github.com/jameslamb/pydistcheck/blob/f6b8027f44472461b1037fc0db98a988ac66144b/setup.cfg#L10-L15

While working on #177, I was starting to look into whether that could be moved into `pyproject.toml`. In the `setuptools` docs about that ([link](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html)), I saw the following description of the `setuptools` table(s) in `pyproject.toml`.

> *some `setuptools`-specific configurations ... are completely optional and probably can be skipped when creating simple packages...*

`pydistcheck` is a simple package. At least, as far as imports are concerned. It's a CLI whose code is organized into separate modules only for development productivity... none of its code is intended to be `import`'d outside the project, and it doesn't have a concept of sub-"packages".

This PR just removes all that configuration replicated `find_packages()`, and switches to relative imports inside the project source code to make the code a bit easier to read and follow.