### PR TITLE
[ci] add more exceptions in smoke tests

### DIFF
--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -100,7 +100,7 @@ pydistcheck \
 get-files opencv-python
 pydistcheck \
     --ignore 'compiled-objects-have-debug-symbols,mixed-file-extensions,unexpected-files' \
-    --max-allowed-files 7200 \
+    --max-allowed-files 7500 \
     --max-allowed-size-compressed '90M' \
     --max-allowed-size-uncompressed '200M' \
     ./smoke-tests/*


### PR DESCRIPTION
Updates smoke tests to work with the latest versions of all the projects it checks.

To fix the following new errors, observed in #177

```text
checking './smoke-tests/opencv-python-4.8.0.74.tar.gz'
------------ check results -----------
1. [too-many-files] Found 7206 files. Only 7200 allowed.
errors found while checking: 1
```

([link to failing build](https://github.com/jameslamb/pydistcheck/actions/runs/5440690446/jobs/9893868473?pr=177))