### PR TITLE
[docs] add example of issue with non-ASCII file names

### DIFF
--- a/docs/check-reference.rst
+++ b/docs/check-reference.rst
@@ -97,6 +97,7 @@ For more information, see:
 * `"Archives Containing Non-ASCII Filenames" (Oracle docs) <https://docs.oracle.com/cd/E36784_01/html/E36823/glnlx.html>`_
 * `example issue from pillow/PIL <https://github.com/python-pillow/Pillow/issues/5077>`_
 * `"Unix and non-ASCII file names, a summary of issues" <https://www.lesbonscomptes.com/recoll/faqsandhowtos/NonAsciiFileNames.html>`_
+* ``jqlang/jq#811``: `"File names with non ASCII characters" <https://github.com/jqlang/jq/issues/811>`_
 
 path-contains-spaces
 ********************


### PR DESCRIPTION
Adds a reference to https://github.com/jqlang/jq/issues/811 to the docs on the non-ASCII check.