### PR TITLE
[ci] use ruff for static analysis

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,15 +24,10 @@ jobs:
             --yes \
             -c conda-forge \
               black \
-              flake8 \
-              flake8-bugbear \
-              flake8-builtins \
-              flake8-comprehensions \
-              flake8-eradicate \
               isort \
               'mypy>=0.931' \
-              'pylint>=2.15.3' \
               requests \
+              ruff \
               shellcheck \
               types-requests
           make lint

--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,8 @@ lint:
 	black \
 		--check \
 		.
-	flake8 --max-line-length=100 .
+	ruff check .
 	mypy .
-	pylint ./src
 
 .PHONY: linux-wheel
 linux-wheel:

--- a/bin/get-release-files.py
+++ b/bin/get-release-files.py
@@ -51,7 +51,7 @@ for file_type, release_files in files_by_type.items():
     print(f"  * {file_type} ({len(release_files)})")
 
 
-for file_type in files_by_type.keys():
+for file_type in files_by_type:
     sample_release = files_by_type[file_type][0]
     output_file = os.path.join(OUTPUT_DIR, sample_release.filename)
     print(f"Downloading '{sample_release.filename}'")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "pydistcheck"
-copyright = "2022-2023, James Lamb"
+copyright = "2022-2023, James Lamb"  # noqa: A001
 author = "James Lamb"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "pydistcheck"
-copyright = "2022, James Lamb"  # noqa: A001
+copyright = "2022-2023, James Lamb"
 author = "James Lamb"
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,24 +68,17 @@ profile = "black"
 exclude = 'docs/conf\.py$|build/*'
 ignore_missing_imports = true
 
-[tool.pylint.messages_control]
-
-max-line-length = 100
-disable = [
-  "invalid-name",
-  "line-too-long",
-  "missing-function-docstring",
-  "too-few-public-methods",
-  "too-many-locals"
-]
-
 [tool.ruff]
-exclude = []
+exclude = [
+    # (pylint) 
+]
 ignore = [
+    # (flake8-simplify) use ternary operator instead of if-else
+    "SIM108",
     # (pycodestyle) Line too long
     "E501",
-    # (flake8-simplify) use ternary operator instead of if-else
-    "SIM108"
+    # (pylint) Magic value used in comparison, consider replacing with a constant
+    "PLR2004"
 ]
 select = [
     # flake8-builtins
@@ -102,6 +95,8 @@ select = [
     "F",
     # pygrep-hooks
     "PGH",
+    # pylint
+    "PL",
     # flake8-return
     "RET",
     # ruff-exclusive checks
@@ -116,5 +111,5 @@ target-version = "py38"
 [tool.ruff.per-file-ignores]
 "tests/*" = [
     # (flake8-bugbear) Found useless expression
-    "B018"
+    "B018",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,12 +88,16 @@ ignore = [
     "SIM108"
 ]
 select = [
+    # flake8-builtins
+    "A",
     # flake8-bugbear
     "B",
     # flake8-comprehensions
     "C4",
     # pycodestyle
     "E",
+    # eradicate
+    "ERA",
     # pyflakes
     "F",
     # pygrep-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,39 @@ disable = [
   "too-few-public-methods",
   "too-many-locals"
 ]
+
+[tool.ruff]
+exclude = []
+ignore = [
+    # (pycodestyle) Line too long
+    "E501",
+    # (flake8-simplify) use ternary operator instead of if-else
+    "SIM108"
+]
+select = [
+    # flake8-bugbear
+    "B",
+    # flake8-comprehensions
+    "C4",
+    # pycodestyle
+    "E",
+    # pyflakes
+    "F",
+    # pygrep-hooks
+    "PGH",
+    # flake8-return
+    "RET",
+    # ruff-exclusive checks
+    "RUF",
+    # flake8-simplify
+    "SIM",
+]
+
+# this should be set to the oldest version of python the project
+target-version = "py38"
+
+[tool.ruff.per-file-ignores]
+"tests/*" = [
+    # (flake8-bugbear) Found useless expression
+    "B018"
+]

--- a/src/pydistcheck/__init__.py
+++ b/src/pydistcheck/__init__.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-module-docstring
 
 # no one should be importing from this package
-__all__ = []  # type: ignore
+__all__ = []  # type: ignore[var-annotated]
 
 __version__ = "0.5.0.99"

--- a/src/pydistcheck/__init__.py
+++ b/src/pydistcheck/__init__.py
@@ -1,5 +1,3 @@
-# pylint: disable=missing-module-docstring
-
 # no one should be importing from this package
 __all__ = []  # type: ignore[var-annotated]
 

--- a/src/pydistcheck/_compat.py
+++ b/src/pydistcheck/_compat.py
@@ -1,5 +1,3 @@
-# pylint: disable=unused-import
-
 """
 Central location for weird import stuff used to make the project compatible
 with a wide range of dependency versions.

--- a/src/pydistcheck/_compat.py
+++ b/src/pydistcheck/_compat.py
@@ -6,6 +6,6 @@ with a wide range of dependency versions.
 """
 
 try:
-    import tomllib  # type: ignore  # noqa: F401
+    import tomllib
 except ModuleNotFoundError:
-    import tomli as tomllib  # type: ignore  # noqa: F401
+    import tomli as tomllib  # type: ignore[no-redef, var-annotated] # noqa: F401

--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -152,14 +152,14 @@ class _NonAsciiCharacterCheck(_CheckProtocol):
 class _MixedFileExtensionCheck(_CheckProtocol):
     check_name = "mixed-file-extensions"
 
-    file_ext_groups = [
+    file_ext_groups = (
         {".cc", ".CC", ".cpp", ".CPP"},
         {".htm", ".HTM", ".html", ".HTML"},
         {".jpg", ".JPG", ".jpeg", ".JPEG"},
         {".jsonl", ".JSONL", ".ndjson", ".NDJSON"},
         {".txt", ".TXT", ".text", ".TEXT"},
         {".yaml", ".YAML", ".yml", ".YML"},
-    ]
+    )
 
     def __call__(self, distro_summary: _DistributionSummary) -> List[str]:
         out: List[str] = []

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -122,7 +122,7 @@ from .utils import _FileSize
         "by ``fnmatch.fnmatchcase()``. See https://docs.python.org/3/library/fnmatch.html."
     ),
 )
-def check(  # pylint: disable=too-many-arguments
+def check(  # noqa: PLR0913
     filepaths: str,
     version: bool,
     config: str,
@@ -164,7 +164,7 @@ def check(  # pylint: disable=too-many-arguments
         conf.update_from_toml(toml_file="pyproject.toml")
     conf.update_from_dict(input_dict=kwargs_that_differ_from_defaults)
 
-    checks_to_ignore = {x for x in conf.ignore.split(",") if x.strip() != ""}
+    checks_to_ignore = {x for x in conf.ignore.split(",") if x.strip()}
     unrecognized_checks = checks_to_ignore - ALL_CHECKS
     if unrecognized_checks:
         # converting to list + sorting here so outputs are deterministic

--- a/src/pydistcheck/config.py
+++ b/src/pydistcheck/config.py
@@ -24,35 +24,39 @@ _ALLOWED_CONFIG_VALUES = {
     "unexpected_file_patterns",
 }
 
-_UNEXPECTED_DIRECTORIES = [
-    "*/.appveyor",
-    "*/.binder",
-    "*/.circleci",
-    "*/.git",
-    "*/.github",
-    "*/.idea",
-    "*/.pytest_cache",
-    "*/.mypy_cache",
-]
+_UNEXPECTED_DIRECTORIES = ",".join(
+    [
+        "*/.appveyor",
+        "*/.binder",
+        "*/.circleci",
+        "*/.git",
+        "*/.github",
+        "*/.idea",
+        "*/.pytest_cache",
+        "*/.mypy_cache",
+    ]
+)
 
-_UNEXPECTED_FILES = [
-    "*/appveyor.yml",
-    "*/.appveyor.yml",
-    "*/azure-pipelines.yml",
-    "*/.azure-pipelines.yml",
-    "*/.cirrus.star",
-    "*/.cirrus.yml",
-    "*/codecov.yml",
-    "*/.codecov.yml",
-    "*/.DS_Store",
-    "*/.gitignore",
-    "*/.gitpod.yml",
-    "*/.hadolint.yaml",
-    "*/.readthedocs.yaml",
-    "*/.travis.yml",
-    "*/vsts-ci.yml",
-    "*/.vsts-ci.yml",
-]
+_UNEXPECTED_FILES = ",".join(
+    [
+        "*/appveyor.yml",
+        "*/.appveyor.yml",
+        "*/azure-pipelines.yml",
+        "*/.azure-pipelines.yml",
+        "*/.cirrus.star",
+        "*/.cirrus.yml",
+        "*/codecov.yml",
+        "*/.codecov.yml",
+        "*/.DS_Store",
+        "*/.gitignore",
+        "*/.gitpod.yml",
+        "*/.hadolint.yaml",
+        "*/.readthedocs.yaml",
+        "*/.travis.yml",
+        "*/vsts-ci.yml",
+        "*/.vsts-ci.yml",
+    ]
+)
 
 
 @dataclass
@@ -62,8 +66,8 @@ class _Config:
     max_allowed_files: int = 2000
     max_allowed_size_compressed: str = "50M"
     max_allowed_size_uncompressed: str = "75M"
-    unexpected_directory_patterns: str = ",".join(_UNEXPECTED_DIRECTORIES)
-    unexpected_file_patterns: str = ",".join(_UNEXPECTED_FILES)
+    unexpected_directory_patterns: str = _UNEXPECTED_DIRECTORIES
+    unexpected_file_patterns: str = _UNEXPECTED_FILES
 
     def __setattr__(self, name: str, value: Any) -> None:
         attr_name = name.replace("-", "_")

--- a/src/pydistcheck/distribution_summary.py
+++ b/src/pydistcheck/distribution_summary.py
@@ -61,9 +61,9 @@ class _FileInfo:
 
 # references:
 #   * https://en.wikipedia.org/wiki/List_of_file_signatures
-#   * https://github.com/apple-oss-distributions/xnu/blob/5c2921b07a2480ab43ec66f5b9e41cb872bc554f/EXTERNAL_HEADERS/mach-o/loader.h#L65  # noqa: E501
-#   * https://github.com/apple-oss-distributions/cctools/blob/658da8c66b4e184458f9c810deca9f6428a773a5/include/mach-o/fat.h#L48  # noqa: E501
-#   * https://github.com/matthew-brett/delocate/blob/df86dddd7c94a93b5c03948b8c127ba0777e2a4d/delocate/tools.py#L166  # noqa: E501
+#   * https://github.com/apple-oss-distributions/xnu/blob/5c2921b07a2480ab43ec66f5b9e41cb872bc554f/EXTERNAL_HEADERS/mach-o/loader.h#L65
+#   * https://github.com/apple-oss-distributions/cctools/blob/658da8c66b4e184458f9c810deca9f6428a773a5/include/mach-o/fat.h#L48
+#   * https://github.com/matthew-brett/delocate/blob/df86dddd7c94a93b5c03948b8c127ba0777e2a4d/delocate/tools.py#L166
 #   * https://learn.microsoft.com/en-us/previous-versions/ms809762(v=msdn.10)
 #   * https://en.wikipedia.org/wiki/Portable_Executable
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -77,13 +77,13 @@ def test_update_from_dict_works_when_changing_all_values(base_config):
 
 def test_update_from_toml_silently_returns_self_if_file_does_not_exist(base_config):
     original_config = deepcopy(base_config)
-    out = base_config.update_from_toml(toml_file=f"{str(uuid.uuid4())}.toml")
+    out = base_config.update_from_toml(toml_file=f"{uuid.uuid4().hex}.toml")
     assert out == original_config
 
 
 def test_update_from_toml_works_for_files_with_no_pydistcheck_configuration(base_config, tmpdir):
     original_config = deepcopy(base_config)
-    temp_file = os.path.join(tmpdir, f"{str(uuid.uuid4())}.toml")
+    temp_file = os.path.join(tmpdir, f"{uuid.uuid4().hex}.toml")
     with open(temp_file, "w") as f:
         f.write("""[tool.pylint]\n""")
     base_config.update_from_toml(toml_file=temp_file)
@@ -92,7 +92,7 @@ def test_update_from_toml_works_for_files_with_no_pydistcheck_configuration(base
 
 def test_update_from_toml_works_for_files_with_empty_pydistcheck_configuration(base_config, tmpdir):
     original_config = deepcopy(base_config)
-    temp_file = os.path.join(tmpdir, f"{str(uuid.uuid4())}.toml")
+    temp_file = os.path.join(tmpdir, f"{uuid.uuid4().hex}.toml")
     with open(temp_file, "w") as f:
         f.write("""\n[tool.pylint]\n[tool.pydistcheck]\n""")
     base_config.update_from_toml(toml_file=temp_file)
@@ -103,7 +103,7 @@ def test_update_from_toml_works_for_files_with_empty_pydistcheck_configuration(b
     "config_key", ["max_allowed_size_compressed", "max-allowed-size_compressed"]
 )
 def test_update_from_toml_works_with_underscores_and_hyphens(base_config, tmpdir, config_key):
-    temp_file = os.path.join(tmpdir, f"{str(uuid.uuid4())}.toml")
+    temp_file = os.path.join(tmpdir, f"{uuid.uuid4().hex}.toml")
     with open(temp_file, "w") as f:
         f.write(f"[tool.pylint]\n[tool.pydistcheck]\n{config_key} = '2.5G'\n")
     base_config.update_from_toml(toml_file=temp_file)
@@ -112,7 +112,7 @@ def test_update_from_toml_works_with_underscores_and_hyphens(base_config, tmpdir
 
 @pytest.mark.parametrize("use_hyphens", [True, False])
 def test_update_from_toml_works_with_all_config_values(base_config, tmpdir, use_hyphens):
-    temp_file = os.path.join(tmpdir, f"{str(uuid.uuid4())}.toml")
+    temp_file = os.path.join(tmpdir, f"{uuid.uuid4().hex}.toml")
     patch_dict = {
         "ignore": "[\n'path-contains-spaces',\n'too-many-files'\n]",
         "inspect": "true",
@@ -141,7 +141,7 @@ def test_update_from_toml_works_with_all_config_values(base_config, tmpdir, use_
 
 
 def test_update_from_toml_converts_lists_to_comma_delimited_string(base_config, tmpdir):
-    temp_file = os.path.join(tmpdir, f"{str(uuid.uuid4())}.toml")
+    temp_file = os.path.join(tmpdir, f"{uuid.uuid4().hex}.toml")
     with open(temp_file, "w") as f:
         f.write(
             "[tool.pylint]\n[tool.pydistcheck]\n"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ def test_file_size_comparisons_work():
     fs_5mb = _FileSize(num=5.6, unit_str="M")
     fs_6mb = _FileSize(num=4 * (1024**3), unit_str="B")
 
-    assert fs_5mb == fs_5mb
+    assert fs_5mb == fs_5mb  # noqa: PLR0124
     assert fs_5mb != fs_6mb
     assert fs_5mb != fs_6mb
     assert fs_5mb < fs_6mb

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,7 +39,7 @@ def test_file_size_from_number_switches_unit_str_based_on_size():
     # fractional bytes don't make sense here, so some rounding happens
     # e.g., 0.1 KB is technically 102.4 bytes, which gets rounded to 102
     assert _FileSize.from_number(102) == _FileSize(num=0.1, unit_str="K")
-    # 3.456789 * 10**3 = 3711698926.043136
+    # this value is 3.456789 * 10**3 = 3711698926.043136
     assert _FileSize.from_number(3711698926) == _FileSize(num=3.456789, unit_str="G")
 
 


### PR DESCRIPTION
Replaces uses of `flake8` and some extensions for it with `ruff`.

`ruff` is faster, implements all the same checks, and has a bunch of other built-in sets of checks.

This PR also fixes the following new warnings from `ruff`:

```text
docs/conf.py:10:33: RUF100 [*] Unused `noqa` directive (non-enabled: `A001`)
src/pydistcheck/__init__.py:4:15: PGH003 Use specific rule codes when ignoring type issues
src/pydistcheck/_compat.py:9:21: PGH003 Use specific rule codes when ignoring type issues
src/pydistcheck/_compat.py:9:37: RUF100 [*] Unused `noqa` directive (unused: `F401`)
src/pydistcheck/_compat.py:11:30: PGH003 Use specific rule codes when ignoring type issues
src/pydistcheck/config.py:65:42: RUF009 Do not perform function call in dataclass defaults
src/pydistcheck/config.py:66:37: RUF009 Do not perform function call in dataclass defaults
src/pydistcheck/distribution_summary.py:64:138: RUF100 [*] Unused `noqa` directive (non-enabled: `E501`)
src/pydistcheck/distribution_summary.py:65:130: RUF100 [*] Unused `noqa` directive (non-enabled: `E501`)
src/pydistcheck/distribution_summary.py:66:119: RUF100 [*] Unused `noqa` directive (non-enabled: `E501`)
docs/conf.py:10:1: A001 Variable `copyright` is shadowing a python builtin
tests/test_utils.py:42:5: ERA001 [*] Found commented-out code
```