### PR TITLE
[ci] use 'mypy --strict'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ lint:
 		--check \
 		.
 	ruff check .
-	mypy --strict ./src
-	mypy --strict ./tests/data
+	mypy ./src
+	mypy ./tests/data
 
 .PHONY: linux-wheel
 linux-wheel:

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ lint:
 		--check \
 		.
 	ruff check .
-	mypy .
+	mypy --strict ./src
+	mypy --strict ./tests/data
 
 .PHONY: linux-wheel
 linux-wheel:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ profile = "black"
 [tool.mypy]
 exclude = 'docs/conf\.py$|build/*'
 ignore_missing_imports = true
+strict = true
 
 [tool.ruff]
 exclude = [

--- a/src/pydistcheck/_compat.py
+++ b/src/pydistcheck/_compat.py
@@ -6,4 +6,6 @@ with a wide range of dependency versions.
 try:
     import tomllib
 except ModuleNotFoundError:
-    import tomli as tomllib  # type: ignore[no-redef, var-annotated] # noqa: F401
+    import tomli as tomllib  # type: ignore[no-redef]
+
+__all__ = ["tomllib"]

--- a/src/pydistcheck/distribution_summary.py
+++ b/src/pydistcheck/distribution_summary.py
@@ -209,7 +209,7 @@ class _DistributionSummary:
         return sum(f.uncompressed_size_bytes for f in self.files)
 
     @property
-    def size_by_file_extension(self) -> OrderedDict:
+    def size_by_file_extension(self) -> "OrderedDict[str, int]":
         """
         Aggregate file sizes in a distribution by extension.
 


### PR DESCRIPTION
Adds use of `--strict` to `mypy` in this project, to get even more thorough type-checking.

See https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-strict

Resolves the following errors raised by it:

```text
src/pydistcheck/distribution_summary.py:212: error: Missing type parameters for generic type "OrderedDict"  [type-arg]
src/pydistcheck/_compat.py:9: error: Unused "type: ignore[var-annotated]" comment  [unused-ignore]
src/pydistcheck/config.py:11: error: Module "pydistcheck._compat" does not explicitly export attribute "tomllib"  [attr-defined]
```