### PR TITLE
[ci] enforce perflint checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,8 @@ select = [
     "ERA",
     # pyflakes
     "F",
+    # perflint
+    "PERF",
     # pygrep-hooks
     "PGH",
     # pylint
@@ -106,7 +108,7 @@ select = [
     "SIM",
 ]
 
-# this should be set to the oldest version of python the project
+# this should be set to the oldest version of python the project supports
 target-version = "py38"
 
 [tool.ruff.per-file-ignores]

--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -119,7 +119,7 @@ class _FilesOnlyDifferByCaseCheck(_CheckProtocol):
             path_lower_to_raw[file_path.lower()].append(file_path)
 
         duplicates_list: List[str] = []
-        for _, filepaths in path_lower_to_raw.items():
+        for filepaths in path_lower_to_raw.values():
             if len(filepaths) > 1:
                 duplicates_list += filepaths
 

--- a/tests/test_distribution_summary.py
+++ b/tests/test_distribution_summary.py
@@ -83,7 +83,7 @@ def test_distribution_summary_basically_works(distro_file):
 
     # size_by_file_extension should return results sorted from largest to smallest by file size
     last_size_seen = float("inf")
-    for _, size_in_bytes in ds.size_by_file_extension.items():
+    for size_in_bytes in ds.size_by_file_extension.values():
         assert size_in_bytes < last_size_seen
         last_size_seen = size_in_bytes
 
@@ -200,7 +200,7 @@ def test_distribution_summary_correctly_reads_contents_of_wheels(distro_file):
 
     # size_by_file_extension should return results sorted from largest to smallest by file size
     last_size_seen = float("inf")
-    for _, size_in_bytes in ds.size_by_file_extension.items():
+    for size_in_bytes in ds.size_by_file_extension.values():
         assert size_in_bytes < last_size_seen
         last_size_seen = size_in_bytes
 


### PR DESCRIPTION
Proposes enforcing the `perflint` checks in this project's CI.

Fixes the following:

```text
src/pydistcheck/checks.py:122:29: PERF102 When using only the values of a dict use the `values()` method
tests/test_distribution_summary.py:86:29: PERF102 When using only the values of a dict use the `values()` method
tests/test_distribution_summary.py:203:29: PERF102 When using only the values of a dict use the `values()` method
```

For more, see https://github.com/tonybaloney/perflint and https://docs.astral.sh/ruff/rules/#perflint-perf.