### PR TITLE
[ci] fix numpy checks in smoke tests

### DIFF
--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -30,7 +30,7 @@ pydistcheck \
 # package where source distro is a .zip
 get-files numpy
 pydistcheck \
-    --ignore 'compiled-objects-have-debug-symbols,unexpected-files' \
+    --ignore 'compiled-objects-have-debug-symbols,mixed-file-extensions,path-contains-spaces,unexpected-files' \
     --max-allowed-files 7500 \
     --max-allowed-size-uncompressed '150M' \
     ./smoke-tests/*

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -31,7 +31,7 @@ pydistcheck \
 get-files numpy
 pydistcheck \
     --ignore 'compiled-objects-have-debug-symbols,unexpected-files' \
-    --max-allowed-files 3000 \
+    --max-allowed-files 7500 \
     --max-allowed-size-uncompressed '150M' \
     ./smoke-tests/*
 


### PR DESCRIPTION
As of `numpy==1.26.1`, `numpy` have decided to bundle 4200+ additional files from `meson`.

That results in 3800+ new errors when checking `numpy` w/ `pydistcheck`, summarized as follows:

```text
1. [mixed-file-extensions] Found a mix of file extensions for the same file type: .cc (35), .cpp (156)
2. [mixed-file-extensions] Found a mix of file extensions for the same file type: .yaml (94), .yml (60)
3-3883. [path-contains-spaces] Found path with spaces ...
...
3884. [too-many-files] Found 7261 files. Only 3000 allowed.
errors found while checking: 3884
```

([build link](https://github.com/jameslamb/pydistcheck/actions/runs/6727481097/job/18285335876?pr=190))

The inclusion of all these new files appears to be intentional:

* https://github.com/numpy/numpy/issues/23981#issuecomment-1656241060
* https://github.com/numpy/numpy/issues/23981#issuecomment-1656286652

This PR adjust the project's smoke tests to allow that.