### PR TITLE
[ci] enforce yamllint checks (fixes #195)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,3 +1,4 @@
+---
 name: Report a bug
 description: Describe a situation where `pydistcheck` behaves differently than expected.
 title: "[bug] "
@@ -23,7 +24,8 @@ body:
       description: |
         Please provide enough information for others investigating this report
         to reproduce the behavior you observed.
-        For help, see the advice in ["How to Create a Minimal, Reproducible Example"](https://stackoverflow.com/help/minimal-reproducible-example).
+        For help, see the advice in
+        ["How to Create a Minimal, Reproducible Example"](https://stackoverflow.com/help/minimal-reproducible-example).
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,3 +1,4 @@
+---
 name: Request some other new feature
 description: Request some feature other than "a new check.
 title: "[feature request] "

--- a/.github/ISSUE_TEMPLATE/new-check.yml
+++ b/.github/ISSUE_TEMPLATE/new-check.yml
@@ -1,3 +1,4 @@
+---
 name: Request a new check
 description: Request that `pydistcheck` complain about something it doesn't complain about today.
 title: "[new check] "

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,4 @@
+---
 name-template: 'v$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
 categories:

--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -1,13 +1,14 @@
+---
 name: build-and-publish-to-pypi
 
 # build wheels and push to PyPI whenever a GitHub release is published
 on:
   push:
     branches:
-    - build/*
+      - build/*
   pull_request:
     branches:
-    - build/*
+      - build/*
   release:
     types:
       - published

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,12 +1,13 @@
+---
 name: docs
 
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
+      - main
 
 jobs:
   test:

--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -1,3 +1,4 @@
+---
 name: manual-run
 
 on:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,3 +1,4 @@
+---
 name: release-drafter
 
 on:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,12 +1,13 @@
+---
 name: smoke-tests
 
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
+      - main
   # run every Wednesday at midnight UTC
   schedule:
     - cron: '0 0 * * 3'
@@ -54,9 +55,9 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs:
-    - test
+      - test
     steps:
-    - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@v1.2.2
-      with:
-        jobs: ${{ toJSON(needs) }}
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,12 +1,13 @@
+---
 name: static-analysis
 
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
+      - main
 
 jobs:
   lint:
@@ -29,7 +30,8 @@ jobs:
               requests \
               ruff \
               shellcheck \
-              types-requests
+              types-requests \
+              yamllint
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
             shfmt

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,12 +1,13 @@
+---
 name: unit-tests
 
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
+      - main
 
 jobs:
   test-cpython:
@@ -148,11 +149,11 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs:
-    - test-cpython
-    - test-pypy
-    - check-test-packages
+      - test-cpython
+      - test-pypy
+      - check-test-packages
     steps:
-    - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@v1.2.2
-      with:
-        jobs: ${{ toJSON(needs) }}
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,3 +1,4 @@
+---
 version: 2
 build:
   os: "ubuntu-20.04"

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ lint:
 	mypy ./tests/data
 	yamllint \
 		--strict \
-		-d '{extends: default, rules: {line-length: {max: 120}}}' \
+		-d '{extends: default, rules: {truthy: {check-keys: false}, line-length: {max: 120}}}' \
 		.
 
 .PHONY: linux-wheel

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ lint:
 	ruff check .
 	mypy ./src
 	mypy ./tests/data
+	yamllint \
+		--strict \
+		-d '{extends: default, rules: {line-length: {max: 120}}}' \
+		.
 
 .PHONY: linux-wheel
 linux-wheel:

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -1,3 +1,4 @@
+---
 name: pydistscheck-docs
 channels:
   - nodefaults


### PR DESCRIPTION
Fixes #195.

Addresses the following:

```text
./.readthedocs.yaml
  1:1       warning  missing document start "---"  (document-start)

./docs/env.yml
  1:1       warning  missing document start "---"  (document-start)

./.github/release-drafter.yml
  1:1       warning  missing document start "---"  (document-start)

./.github/workflows/static-analysis.yml
  1:1       warning  missing document start "---"  (document-start)
  6:5       error    wrong indentation: expected 6 but found 4  (indentation)
  9:5       error    wrong indentation: expected 6 but found 4  (indentation)

./.github/workflows/manual-run.yml
  1:1       warning  missing document start "---"  (document-start)

./.github/workflows/smoke-tests.yml
  1:1       warning  missing document start "---"  (document-start)
  6:5       error    wrong indentation: expected 6 but found 4  (indentation)
  9:5       error    wrong indentation: expected 6 but found 4  (indentation)
  57:5      error    wrong indentation: expected 6 but found 4  (indentation)
  59:5      error    wrong indentation: expected 6 but found 4  (indentation)

./.github/workflows/build-and-publish-wheels.yml
  1:1       warning  missing document start "---"  (document-start)
  7:5       error    wrong indentation: expected 6 but found 4  (indentation)
  10:5      error    wrong indentation: expected 6 but found 4  (indentation)

./.github/workflows/unit-tests.yml
  1:1       warning  missing document start "---"  (document-start)
  6:5       error    wrong indentation: expected 6 but found 4  (indentation)
  9:5       error    wrong indentation: expected 6 but found 4  (indentation)
  151:5     error    wrong indentation: expected 6 but found 4  (indentation)
  155:5     error    wrong indentation: expected 6 but found 4  (indentation)

./.github/workflows/release-drafter.yml
  1:1       warning  missing document start "---"  (document-start)

./.github/workflows/check-docs.yml
  1:1       warning  missing document start "---"  (document-start)
  6:5       error    wrong indentation: expected 6 but found 4  (indentation)
  9:5       error    wrong indentation: expected 6 but found 4  (indentation)

./.github/ISSUE_TEMPLATE/bug-report.yml
  1:1       warning  missing document start "---"  (document-start)
  26:121    error    line too long (147 > 120 characters)  (line-length)

./.github/ISSUE_TEMPLATE/new-check.yml
  1:1       warning  missing document start "---"  (document-start)

./.github/ISSUE_TEMPLATE/feature-request.yml
  1:1       warning  missing document start "---"  (document-start)
```

Ref:

* https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy
* https://github.com/adrienverge/yamllint