### PR TITLE
fix compiled-objects-have-debug-symbols on macOS

### DIFF
--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -30,7 +30,7 @@ pydistcheck \
 # package where source distro is a .zip
 get-files numpy
 pydistcheck \
-    --ignore 'mixed-file-extensions,path-contains-spaces,unexpected-files' \
+    --ignore 'compiled-objects-have-debug-symbols,mixed-file-extensions,path-contains-spaces,unexpected-files' \
     --max-allowed-files 7500 \
     --max-allowed-size-uncompressed '150M' \
     ./smoke-tests/*

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -87,6 +87,7 @@ pydistcheck \
 
 get-files datatable
 pydistcheck \
+    --ignore 'compiled-objects-have-debug-symbols' \
     --max-allowed-size-compressed '100M' \
     --max-allowed-size-uncompressed '100M' \
     ./smoke-tests/*

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -94,7 +94,7 @@ pydistcheck \
 
 get-files gensim
 pydistcheck \
-    --igore 'compiled-objects-have-debug-symbols' \
+    --ignore 'compiled-objects-have-debug-symbols' \
     ./smoke-tests/*
 
 get-files opencv-python

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -77,7 +77,7 @@ pydistcheck ./smoke-tests/*
 # other complex projects that do custom packaging stuff
 get-files apache-airflow
 pydistcheck \
-    --ignore 'mixed-file-extensions' \
+    --ignore 'mixed-file-extensions,unexpected-files' \
     ./smoke-tests/*
 
 get-files astropy

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -38,7 +38,7 @@ pydistcheck \
 # package with so many files that `find -exec du -ch` has to batch results
 get-files tensorflow
 pydistcheck \
-    --ignore 'mixed-file-extensions' \
+    --ignore 'compiled-objects-have-debug-symbols,mixed-file-extensions' \
     --max-allowed-files 15000 \
     --max-allowed-size-compressed '500M' \
     --max-allowed-size-uncompressed '1.5G' \

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -110,6 +110,7 @@ pydistcheck ./smoke-tests/*
 
 get-files Pillow
 pydistcheck \
+    --ignore 'compiled-objects-have-debug-symbols' \
     ./smoke-tests/*
 
 get-files pytest

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -99,7 +99,7 @@ pydistcheck \
 
 get-files opencv-python
 pydistcheck \
-    --ignore 'mixed-file-extensions,unexpected-files' \
+    --ignore 'compiled-objects-have-debug-symbols,mixed-file-extensions,unexpected-files' \
     --max-allowed-files 7500 \
     --max-allowed-size-compressed '90M' \
     --max-allowed-size-uncompressed '200M' \

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -94,6 +94,7 @@ pydistcheck \
 
 get-files gensim
 pydistcheck \
+    --igore 'compiled-objects-have-debug-symbols' \
     ./smoke-tests/*
 
 get-files opencv-python

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -125,10 +125,12 @@ pydistcheck \
 
 get-files Shapely
 pydistcheck \
+    --ignore 'compiled-objects-have-debug-symbols' \
     ./smoke-tests/*
 
 get-files spacy
 pydistcheck \
+    --ignore 'compiled-objects-have-debug-symbols' \
     ./smoke-tests/*
 
 echo "done running smoke tests"

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -30,7 +30,7 @@ pydistcheck \
 # package where source distro is a .zip
 get-files numpy
 pydistcheck \
-    --ignore 'compiled-objects-have-debug-symbols,mixed-file-extensions,path-contains-spaces,unexpected-files' \
+    --ignore 'mixed-file-extensions,path-contains-spaces,unexpected-files' \
     --max-allowed-files 7500 \
     --max-allowed-size-uncompressed '150M' \
     ./smoke-tests/*
@@ -38,7 +38,7 @@ pydistcheck \
 # package with so many files that `find -exec du -ch` has to batch results
 get-files tensorflow
 pydistcheck \
-    --ignore 'compiled-objects-have-debug-symbols,mixed-file-extensions' \
+    --ignore 'mixed-file-extensions' \
     --max-allowed-files 15000 \
     --max-allowed-size-compressed '500M' \
     --max-allowed-size-uncompressed '1.5G' \
@@ -56,7 +56,7 @@ pydistcheck \
 # package that isn't actually Python code
 get-files cmake
 pydistcheck \
-    --ignore 'compiled-objects-have-debug-symbols,mixed-file-extensions,path-contains-spaces,unexpected-files' \
+    --ignore 'mixed-file-extensions,path-contains-spaces,unexpected-files' \
     --max-allowed-files 4000 \
     --max-allowed-size-uncompressed '150M' \
     ./smoke-tests/*
@@ -82,24 +82,22 @@ pydistcheck \
 
 get-files astropy
 pydistcheck \
-    --ignore 'compiled-objects-have-debug-symbols,mixed-file-extensions,unexpected-files' \
+    --ignore 'mixed-file-extensions,unexpected-files' \
     ./smoke-tests/*
 
 get-files datatable
 pydistcheck \
-    --ignore 'compiled-objects-have-debug-symbols' \
     --max-allowed-size-compressed '100M' \
     --max-allowed-size-uncompressed '100M' \
     ./smoke-tests/*
 
 get-files gensim
 pydistcheck \
-    --ignore 'compiled-objects-have-debug-symbols' \
     ./smoke-tests/*
 
 get-files opencv-python
 pydistcheck \
-    --ignore 'compiled-objects-have-debug-symbols,mixed-file-extensions,unexpected-files' \
+    --ignore 'mixed-file-extensions,unexpected-files' \
     --max-allowed-files 7500 \
     --max-allowed-size-compressed '90M' \
     --max-allowed-size-uncompressed '200M' \
@@ -110,7 +108,6 @@ pydistcheck ./smoke-tests/*
 
 get-files Pillow
 pydistcheck \
-    --ignore 'compiled-objects-have-debug-symbols' \
     ./smoke-tests/*
 
 get-files pytest
@@ -120,17 +117,15 @@ pydistcheck \
 
 get-files scikit-learn
 pydistcheck \
-    --ignore 'compiled-objects-have-debug-symbols,mixed-file-extensions,unexpected-files' \
+    --ignore 'mixed-file-extensions,unexpected-files' \
     ./smoke-tests/*
 
 get-files Shapely
 pydistcheck \
-    --ignore 'compiled-objects-have-debug-symbols' \
     ./smoke-tests/*
 
 get-files spacy
 pydistcheck \
-    --ignore 'compiled-objects-have-debug-symbols' \
     ./smoke-tests/*
 
 echo "done running smoke tests"

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -56,7 +56,7 @@ pydistcheck \
 # package that isn't actually Python code
 get-files cmake
 pydistcheck \
-    --ignore 'mixed-file-extensions,path-contains-spaces,unexpected-files' \
+    --ignore 'compiled-objects-have-debug-symbols,mixed-file-extensions,path-contains-spaces,unexpected-files' \
     --max-allowed-files 4000 \
     --max-allowed-size-uncompressed '150M' \
     ./smoke-tests/*

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -82,7 +82,7 @@ pydistcheck \
 
 get-files astropy
 pydistcheck \
-    --ignore 'mixed-file-extensions,unexpected-files' \
+    --ignore 'compiled-objects-have-debug-symbols,mixed-file-extensions,unexpected-files' \
     ./smoke-tests/*
 
 get-files datatable

--- a/src/pydistcheck/config.py
+++ b/src/pydistcheck/config.py
@@ -4,6 +4,7 @@ Manages configuration of ``pydistcheck` CLI, including:
   * validating configuration values
   * updating configuuration from files
 """
+
 import os
 from dataclasses import dataclass
 from typing import Any, Dict

--- a/src/pydistcheck/shared_lib_utils.py
+++ b/src/pydistcheck/shared_lib_utils.py
@@ -65,8 +65,8 @@ def _get_symbols(cmd_args: List[str], lib_file: str) -> str:
 
 def _nm_reports_debug_symbols(tool_name: str, lib_file: str) -> Tuple[bool, str]:
     exported_symbols = _get_symbols(cmd_args=[tool_name], lib_file=lib_file)
-    all_symbols = _get_symbols(cmd_args=[tool_name, "--debug-syms"], lib_file=lib_file)
-    return exported_symbols != all_symbols, f"{tool_name} --debug-syms"
+    all_symbols = _get_symbols(cmd_args=[tool_name, "-a"], lib_file=lib_file)
+    return exported_symbols != all_symbols, f"{tool_name} -a"
 
 
 def _archive_member_has_debug_symbols(archive_file: str, file_info: _FileInfo) -> Tuple[bool, str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -557,7 +557,7 @@ def test_debug_symbols_check_works(distro_file):
     assert result.exit_code == 1, result.output
     if "macosx" in distro_file:
         if platform.startswith("cygwin") or platform.startswith("win"):
-            debug_cmd = r"'llvm\-nm \-\-debug\-syms \"lib/lib_baseballmetrics\.dylib\"'\."
+            debug_cmd = r"'llvm\-nm \-a \"lib/lib_baseballmetrics\.dylib\"'\."
         else:
             # dsymutil works on both macOS and Linux
             debug_cmd = r"'dsymutil \-s \"lib/lib_baseballmetrics\.dylib\"'\."


### PR DESCRIPTION
Running this project's unit tests on my mac today (macOS 12.2.1, intel chip), I found 2 test failures that don't show up in CI:

```text
E       AssertionError: ==================== running pydistcheck ====================
E         
E         checking '/Users/jlamb/repos/pydistcheck/tests/data/baseballmetrics-0.1.0-py3-none-macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_5_x86_64.whl'
E         ------------ check results -----------
E         1. [compiled-objects-have-debug-symbols] Found compiled object containing debug symbols. For details, extract the distribution contents and run 'nm --debug-syms "lib/lib_baseballmetrics.dylib"'.
```

It seems that the `nm` distributed with Xcode does not support argument `--debug-syms` ([docs](https://keith.github.io/xcode-man-pages/nm.1.html)), while GNU `nm` ([docs](https://sourceware.org/binutils/docs/binutils/nm.html)) and `llvm-nm` ([docs](https://llvm.org/docs/CommandGuide/llvm-nm.html)) do.

All 3 support `-a` to accomplish the same thing.

This proposes using `nm -a` instead of `nm --debug-syms`.

### Benefits of this change

Removes a source of false positives for the `compiled-objects-have-debug-symbols` check.
