### PR TITLE
bump development version

### DIFF
--- a/src/pydistcheck/__init__.py
+++ b/src/pydistcheck/__init__.py
@@ -1,4 +1,4 @@
 # no one should be importing from this package
 __all__ = []  # type: ignore[var-annotated]
 
-__version__ = "0.5.2"
+__version__ = "0.5.2.99"


### PR DESCRIPTION
Bumping the version to `0.5.2.99`, per https://github.com/jameslamb/pydistcheck/blob/main/CONTRIBUTING.md.