### PR TITLE
[ci] fix package uploads

### DIFF
--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -23,6 +23,7 @@ jobs:
         run: pipx run build --wheel
       - uses: actions/upload-artifact@v4
         with:
+          name: wheel
           path: dist/*.whl
 
   build_sdist:
@@ -34,6 +35,7 @@ jobs:
         run: pipx run build --sdist
       - uses: actions/upload-artifact@v4
         with:
+          name: sdist
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -44,7 +46,11 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: sdist
+          path: dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
           path: dist
       - uses: pypa/gh-action-pypi-publish@v1.8.11
         with:


### PR DESCRIPTION
Starting with v4 of https://github.com/actions/upload-artifact, a single workflow run cannot upload multiple artifacts with the same name.

As a result, publishing v0.5.2 to PyPI failed like this:

```text
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

([build link](https://github.com/jameslamb/pydistcheck/actions/runs/7677156874))