### PR TITLE
[ci] add more extensions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 _build/
 build/
 *.bz
+*.bz2
 *.core
 *.coverage
 *.css
@@ -27,6 +28,7 @@ htmlcov/
 .idea/
 *.js
 *.json
+*.lzma
 .mypy_cache/
 *.npy
 *.o
@@ -40,7 +42,11 @@ htmlcov/
 *.pyc
 __pycache__/
 .pytest_cache/
+*.rda
+*.rds
+*.Rdata
 *.rsa
+scratch.md
 _skbuild/
 smoke-tests/
 *.snappy-*.tar.gz
@@ -56,6 +62,7 @@ wheels/
 *.xlsx
 *.xlsm
 *.zip
+*.zstd
 
 # exclusions
 !tests/data/baseballmetrics-0.1.0-py3-none-macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_5_x86_64.whl

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _build/
 build/
 *.bz
 *.bz2
+*.conda
 *.core
 *.coverage
 *.css


### PR DESCRIPTION
Contributes to #200.

Adds more extensions for packaging-related files to `.gitignore`.