### PR TITLE
introduce file_utils module

### DIFF
--- a/src/pydistcheck/distribution_summary.py
+++ b/src/pydistcheck/distribution_summary.py
@@ -12,10 +12,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import Dict, List, Tuple, Union
 
-
-@dataclass
-class _DirectoryInfo:
-    name: str
+from .file_utils import _DirectoryInfo
 
 
 @dataclass

--- a/src/pydistcheck/file_utils.py
+++ b/src/pydistcheck/file_utils.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class _DirectoryInfo:
+    name: str


### PR DESCRIPTION
Contributes to #200 .

Starts to move some internal functions and dataclasses related to files out of `srs/distribution_summary.py` and into a module `src/file_utils.py`.

Having checks in `checks.py` import `distribution_summary` creates a circular dependency problem (since other modules want to import both of them). Moving this stuff into a place they both import helps with that.

See #204 for more details on where these changes are going.