### PR TITLE
centralize archive-format detection

### DIFF
--- a/src/pydistcheck/file_utils.py
+++ b/src/pydistcheck/file_utils.py
@@ -4,3 +4,21 @@ from dataclasses import dataclass
 @dataclass
 class _DirectoryInfo:
     name: str
+
+
+class _ArchiveFormat:
+    BZIP2_TAR = ".tar.bz2"
+    CONDA = ".conda"
+    GZIP_TAR = ".tar.gz"
+    ZIP = ".zip"
+
+
+def _guess_archive_format(filename: str) -> str:
+    if filename.endswith("gz"):
+        return _ArchiveFormat.GZIP_TAR
+    if filename.endswith("bz2"):
+        return _ArchiveFormat.BZIP2_TAR
+    if filename.endswith(".conda"):
+        return _ArchiveFormat.CONDA
+
+    return _ArchiveFormat.ZIP


### PR DESCRIPTION
Contributes to #200.

Currently, this project only supports 3 formats:

* `.whl` (zip-format built distribution)
* `.tar.gz` (gzip-compressed, tar-format source distribution)
* `.zip` (zip-format distribution)

Adding conda package support will add 2 more things:

* `.tar.bz2` (gzip-compressed, tar-format distribution)
* `.conda` (bzip2-compress, zip-format distribution containing multiple zstd-compressed tar-format archives)

This PR centralizes the code for determining which, if any, of those formats a provided file is in. That should help reduce duplication, and provide a clearer place to work on in the future to make that detection more reliable than simple pattern-matching on file extensions.