### PR TITLE
[docs] add Windows trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: POSIX",
     "Operating System :: Unix",
+    "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
Adds a trove classifier indicating that `pydistcheck` works on Windows.

Specific formatting from https://github.com/pypa/trove-classifiers/blob/e5c379567a6a5d67c5a2505d6429faca5b69fc45/src/trove_classifiers/__init__.py#L404.

This helps categorization on indices like PyPI, e.g. to support queries like "all projects that say they work on Windows".

### Evidence supporting this addition

This project's full test suite runs on Windows on every commit.