### PR TITLE
[ci] add flake8-bandit checks

### DIFF
--- a/bin/get-release-files.py
+++ b/bin/get-release-files.py
@@ -10,7 +10,7 @@ OUTPUT_DIR = sys.argv[2]
 PYPI_URL = "https://pypi.org"
 
 print(f"Getting PyPI details for package '{PACKAGE_NAME}'")
-res = requests.get(url=f"{PYPI_URL}/pypi/{PACKAGE_NAME}/json")
+res = requests.get(url=f"{PYPI_URL}/pypi/{PACKAGE_NAME}/json", timeout=30)
 res.raise_for_status()
 release_info = res.json()
 
@@ -61,7 +61,9 @@ for file_type in files_by_type:
     sample_release = files_by_type[file_type][0]
     output_file = os.path.join(OUTPUT_DIR, sample_release.filename)
     print(f"Downloading '{sample_release.filename}'")
-    res = requests.get(url=sample_release.url, headers={"Accept": "application/octet-stream"})
+    res = requests.get(
+        url=sample_release.url, headers={"Accept": "application/octet-stream"}, timeout=30
+    )
     res.raise_for_status()
     with open(output_file, "wb") as f:
         f.write(res.content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,12 +79,14 @@ exclude = [
     # (pylint) 
 ]
 ignore = [
-    # (flake8-simplify) use ternary operator instead of if-else
-    "SIM108",
     # (pycodestyle) Line too long
     "E501",
     # (pylint) Magic value used in comparison, consider replacing with a constant
-    "PLR2004"
+    "PLR2004",
+    # (flake8-bandit) subprocess call: check for execution of untrusted input
+    "S603",
+    # (flake8-simplify) use ternary operator instead of if-else
+    "SIM108"
 ]
 select = [
     # flake8-builtins
@@ -109,6 +111,8 @@ select = [
     "RET",
     # ruff-exclusive checks
     "RUF",
+    # flake8-bandit
+    "S",
     # flake8-simplify
     "SIM",
 ]
@@ -120,4 +124,6 @@ target-version = "py38"
 "tests/*" = [
     # (flake8-bugbear) Found useless expression
     "B018",
+    # (flake8-bandit) use of assert detected
+    "S101"
 ]

--- a/src/pydistcheck/file_utils.py
+++ b/src/pydistcheck/file_utils.py
@@ -121,10 +121,12 @@ def _guess_archive_member_file_format(
             header = f.read(4)
     else:
         fileobj = archive_file.extractfile(member_name)
-        assert fileobj is not None, (
-            f"'{member_name}' not found. This is a bug in pydistcheck."
-            "Report it at https://github.com/jameslamb/pydistcheck/issues."
-        )
+        if fileobj is None:
+            error_msg = (
+                f"'{member_name}' not found. This is a bug in pydistcheck."
+                "Report it at https://github.com/jameslamb/pydistcheck/issues."
+            )
+            raise RuntimeError(error_msg)
         header = fileobj.read(4)
 
     if header in _ELF_MAGIC_FIRST_4_BYTES:


### PR DESCRIPTION
Adds the `flake8-bandit` checks (run by `ruff`) to the project's linting.

From https://pypi.org/project/flake8-bandit/

> *Automated security testing built right into your workflow*

It found these things:

```text
bin/get-release-files.py:13:7: S113 Probable use of requests call without timeout
bin/get-release-files.py:64:11: S113 Probable use of requests call without timeout
src/pydistcheck/file_utils.py:124:9: S101 Use of `assert` detected
src/pydistcheck/shared_lib_utils.py:21:33: S603 `subprocess` call: check for execution of untrusted input
```