### PR TITLE
avoid duplicate file I/O for 'compiled-objects-have-debug-symbols'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"src/pydistcheck/shared_lib_utils.py" = [
+"src/pydistcheck/*" = [
     # uses of tarfile.extractall()
     "S202"
 ]

--- a/src/pydistcheck/file_utils.py
+++ b/src/pydistcheck/file_utils.py
@@ -2,7 +2,7 @@ import pathlib
 import tarfile
 import zipfile
 from dataclasses import dataclass
-from typing import Tuple, Union
+from typing import List, Tuple, Union
 
 
 @dataclass
@@ -137,3 +137,32 @@ def _guess_archive_member_file_format(
         return _FileFormat.WINDOWS_PE, True
 
     return _FileFormat.OTHER, False
+
+
+def _extract_subset_of_files_from_archive(
+    archive_file: str, archive_format: str, relative_paths: List[str], out_dir: str
+) -> None:
+    """
+    Extract a subset of files from an archive to a destination directory.
+
+    Extracts AT LEAST those files... might in some cases extract all files.
+    """
+    if archive_format == _ArchiveFormat.ZIP:
+        with zipfile.ZipFile(archive_file, mode="r") as zf:
+            zf.extractall(path=out_dir, members=relative_paths)
+    elif archive_format == _ArchiveFormat.BZIP2_TAR:
+        with tarfile.open(archive_file, mode="r:bz2") as tf:
+            tf.extractall(
+                path=out_dir,
+                members=[tf.getmember(p) for p in relative_paths],
+                filter="data",
+            )
+    elif archive_format == _ArchiveFormat.GZIP_TAR:
+        with tarfile.open(archive_file, mode="r:gz") as tf:
+            tf.extractall(
+                path=out_dir,
+                members=[tf.getmember(p) for p in relative_paths],
+                filter="data",
+            )
+    else:
+        raise RuntimeError(f"files of format '{archive_format}' are not supported")


### PR DESCRIPTION
Contributes to #200.

The `compiled-objects-have-debug-symbols' checks works by extracting actual file content from a file distribution, writing it out to a temporary directory, and then running a bunch of tools against it using `subprocess`.

Today, it does that with logic like this pseudcode:

```text
for file in list_of_compiled_objects:
    tmp_dir = create_temp_directory()
    extract_to_tmp_dir(archive, file, tmp_dir)
    for tool in symbol_checking_tools:
        run_tool(tool, f"{tmp_dir}/{file}")
```

For packages with `n` compiled objects, that pattern will result in creating and deleting `n` temporary directory, and extracting files by opening the archive file `n` times.

This PR proposes extracting all of the relevant files at once... 1 temporary directory, 1 time opening the archive file. Like this pseudocode

```text
tmp_dir = create_temp_directory()
extract_to_tmp_dir(archive, list_of_compiled_objects, tmp_dir)
for tool in symbol_checking_tools:
   run_tool(tool, f"{tmp_dir}/{file}")
```

### Benefits of this change

Makes `compiled-objects-have-debug-symbols` faster for packages with `> 1` compiled objects.

This is extra relevant for `.conda` packages, where extracting the relevant files is a 2-step process involving `zip`-decompressing the outer archive and then `zstd`-untarring the inner ones. As of this change, that'll only have to be done once.