### PR TITLE
prevent exit codes greater than 255

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,10 @@ select = [
     # uses of tarfile.extractall()
     "S202"
 ]
+"src/pydistcheck/cli.py" = [
+    # Too many branches
+    "PLR0912"
+]
 "tests/*" = [
     # (flake8-bugbear) Found useless expression
     "B018",

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -27,6 +27,11 @@ from .inspect import inspect_distribution
 from .utils import _FileSize
 
 
+class ExitCodes:
+    OK = 0
+    CHECK_ERRORS = 1
+
+
 @click.command()
 @click.argument(
     "filepaths",
@@ -137,10 +142,15 @@ def check(  # noqa: PLR0913
     """
     Run the contents of a distribution through a set of checks, and warn about
     any problematic characteristics that are detected.
+
+    Exit codes:
+
+      0 = no issues detected\n
+      1 = issues detected
     """
     if version:
         print(f"pydistcheck {_VERSION}")
-        sys.exit(0)
+        sys.exit(ExitCodes.OK)
 
     print("==================== running pydistcheck ====================")
     filepaths_to_check = [click.format_filename(f) for f in filepaths]
@@ -226,4 +236,7 @@ def check(  # noqa: PLR0913
 
     # now that all files have been checked, be sure to exit with a non-0 code
     # if any errors were found
-    sys.exit(int(any_errors_found))
+    if any_errors_found:
+        sys.exit(ExitCodes.CHECK_ERRORS)
+    else:
+        sys.exit(ExitCodes.OK)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,8 @@ def test_version_flag_works():
 def test_check_fails_with_informative_error_if_file_doesnt_exist():
     runner = CliRunner()
     result = runner.invoke(check, ["some-garbage.exe"])
-    assert result.exit_code == 1
+    # NOTE: this exit code comes from 'click'
+    assert result.exit_code >= 1
     _assert_log_matches_pattern(result, r"Path 'some\-garbage\.exe' does not exist\.$")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,7 @@ def test_version_flag_works():
 def test_check_fails_with_informative_error_if_file_doesnt_exist():
     runner = CliRunner()
     result = runner.invoke(check, ["some-garbage.exe"])
-    assert result.exit_code > 0
+    assert result.exit_code == 1
     _assert_log_matches_pattern(result, r"Path 'some\-garbage\.exe' does not exist\.$")
 
 


### PR DESCRIPTION
`pydistcheck` currently returns a different exit code depending on how many errors are found.

https://github.com/jameslamb/pydistcheck/blob/bfcaa481ba1f9f1398b4fa04d85bc129949a8d1f/src/pydistcheck/cli.py#L229

That's unnecessary... it's enough for all use cases I can think of for `pydistcheck` to exit with 0 on success and 1 on not success.

But worse than that... this scheme opens up the possibility of returning exit codes `>255`. Some operating systems don't support those, and even worse... some will wrap around, like this:

```shell
cat << EOF > ./test.sh
exit 256
EOF

sh ./test.sh
echo $?
# 0
```

😱 in that case, running `pydistcheck` on a file with exactly 256  issues (or 512, or 768, etc.) would look like a success to the operating system. That's problematic for any non-interactive cases, like running `pydistcheck` in continuous integration to try to catch issues.

This PR eliminates that possibility. As of this PR, `pydistcheck` will return only the following exit codes:

```text
0 = no issues detected
1 = issues detected
```

### References

* https://unix.stackexchange.com/questions/37915/why-do-i-get-error-255-when-returning-1
* https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html