### PR TITLE
raise an informative error on unrecognized file format

### DIFF
--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -30,6 +30,7 @@ from .utils import _FileSize
 class ExitCodes:
     OK = 0
     CHECK_ERRORS = 1
+    UNSUPPORTED_FILE_TYPE = 2
 
 
 @click.command()
@@ -213,13 +214,19 @@ def check(  # noqa: PLR0913
     for filepath in filepaths_to_check:
         print(f"\nchecking '{filepath}'")
 
+        try:
+            summary = _DistributionSummary.from_file(filename=filepath)
+        except ValueError as err:
+            print(f"error: {err}")
+            sys.exit(ExitCodes.UNSUPPORTED_FILE_TYPE)
+
         if conf.inspect:
             print("----- package inspection summary -----")
-            inspect_distribution(filepath=filepath)
+            inspect_distribution(summary)
 
         print("------------ check results -----------")
-        summary = _DistributionSummary.from_file(filename=filepath)
         errors: List[str] = []
+        summary = _DistributionSummary.from_file(filename=filepath)
         for this_check in checks:
             errors += this_check(distro_summary=summary)
 

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -226,7 +226,6 @@ def check(  # noqa: PLR0913
 
         print("------------ check results -----------")
         errors: List[str] = []
-        summary = _DistributionSummary.from_file(filename=filepath)
         for this_check in checks:
             errors += this_check(distro_summary=summary)
 

--- a/src/pydistcheck/file_utils.py
+++ b/src/pydistcheck/file_utils.py
@@ -18,14 +18,22 @@ class _ArchiveFormat:
 
 
 def _guess_archive_format(filename: str) -> str:
-    if filename.endswith("gz"):
+    if filename.lower().endswith("gz"):
         return _ArchiveFormat.GZIP_TAR
-    if filename.endswith("bz2"):
+    if filename.lower().endswith("bz2"):
         return _ArchiveFormat.BZIP2_TAR
-    if filename.endswith(".conda"):
+    if filename.lower().endswith(".conda"):
         return _ArchiveFormat.CONDA
+    if filename.lower().endswith(".zip"):
+        return _ArchiveFormat.ZIP
+    if filename.lower().endswith(".whl"):
+        return _ArchiveFormat.ZIP
 
-    return _ArchiveFormat.ZIP
+    raise ValueError(
+        f"File '{filename}' does not appear to be a Python package distribution in "
+        "one of the formats supported by 'pydistcheck'. "
+        "Supported formats: .conda, .tar.bz2, .tar.gz, .whl, .zip"
+    )
 
 
 @dataclass

--- a/src/pydistcheck/inspect.py
+++ b/src/pydistcheck/inspect.py
@@ -2,12 +2,14 @@
 Code that prints diagnostic information about a distribution.
 """
 
-from .distribution_summary import _DistributionSummary
+from typing import TYPE_CHECKING
 from .utils import _FileSize
 
+if TYPE_CHECKING:
+    from .distribution_summary import _DistributionSummary
 
-def inspect_distribution(filepath: str) -> None:
-    summary = _DistributionSummary.from_file(filename=filepath)
+
+def inspect_distribution(summary: "_DistributionSummary") -> None:
     print("file size")
     compressed_size = _FileSize(summary.compressed_size_bytes, "B")
     uncompressed_size = _FileSize(summary.uncompressed_size_bytes, "B")

--- a/src/pydistcheck/inspect.py
+++ b/src/pydistcheck/inspect.py
@@ -3,6 +3,7 @@ Code that prints diagnostic information about a distribution.
 """
 
 from typing import TYPE_CHECKING
+
 from .utils import _FileSize
 
 if TYPE_CHECKING:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,6 +98,19 @@ def test_check_runs_for_all_files_before_exiting():
         result=result, pattern="errors found while checking\\: 1", num_times=2
     )
 
+@pytest.mark.parametrize("flags", ([], ["--inspect"]))
+def test_check_fails_with_informative_error_if_file_is_an_unrecognized_format(flags):
+    runner = CliRunner()
+    result = runner.invoke(check, [__file__, *flags])
+    assert result.exit_code == 2
+    _assert_log_matches_pattern(
+        result,
+        (
+            f"error: File '{__file__}' does not appear to be a Python package distribution "
+            "in one of the formats supported by 'pydistcheck'\. Supported formats\:"
+        ),
+    )
+
 
 @pytest.mark.parametrize("distro_file", BASE_PACKAGES)
 def test_check_respects_ignore_with_one_check(distro_file):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,6 +98,7 @@ def test_check_runs_for_all_files_before_exiting():
         result=result, pattern="errors found while checking\\: 1", num_times=2
     )
 
+
 @pytest.mark.parametrize("flags", ([], ["--inspect"]))
 def test_check_fails_with_informative_error_if_file_is_an_unrecognized_format(flags):
     runner = CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -107,8 +107,8 @@ def test_check_fails_with_informative_error_if_file_is_an_unrecognized_format(fl
     _assert_log_matches_pattern(
         result,
         (
-            f"error: File '{__file__}' does not appear to be a Python package distribution "
-            "in one of the formats supported by 'pydistcheck'\. Supported formats\:"
+            rf"error: File '{__file__}' does not appear to be a Python package distribution "
+            r"in one of the formats supported by 'pydistcheck'\. Supported formats\:"
         ),
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,11 +105,7 @@ def test_check_fails_with_informative_error_if_file_is_an_unrecognized_format(fl
     result = runner.invoke(check, [__file__, *flags])
     assert result.exit_code == 2
     _assert_log_matches_pattern(
-        result,
-        (
-            rf"error: File '{__file__}' does not appear to be a Python package distribution "
-            r"in one of the formats supported by 'pydistcheck'. Supported formats"
-        ),
+        result, r"error.*File '.*' does not appear to be a Python package distribution"
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,7 +108,7 @@ def test_check_fails_with_informative_error_if_file_is_an_unrecognized_format(fl
         result,
         (
             rf"error: File '{__file__}' does not appear to be a Python package distribution "
-            r"in one of the formats supported by 'pydistcheck'\. Supported formats\:"
+            r"in one of the formats supported by 'pydistcheck'. Supported formats"
         ),
     )
 


### PR DESCRIPTION
Contributes to #200.

As of v0.5.2, when you run `pydistcheck` on a file that isn't in one of the formats it recognizes, the response is a little unpleasant.

```shell
pydistcheck ./README.md
```

```text
==================== running pydistcheck ====================

checking './README.md'
------------ check results -----------
Traceback (most recent call last):
  File "/Users/jlamb/mambaforge/envs/pydistcheck-dev/bin/pydistcheck", line 8, in <module>
    sys.exit(check())
             ^^^^^^^
  File "/Users/jlamb/mambaforge/envs/pydistcheck-dev/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jlamb/mambaforge/envs/pydistcheck-dev/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/jlamb/mambaforge/envs/pydistcheck-dev/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jlamb/mambaforge/envs/pydistcheck-dev/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jlamb/mambaforge/envs/pydistcheck-dev/lib/python3.11/site-packages/pydistcheck/cli.py", line 211, in check
    summary = _DistributionSummary.from_file(filename=filepath)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jlamb/mambaforge/envs/pydistcheck-dev/lib/python3.11/site-packages/pydistcheck/distribution_summary.py", line 153, in from_file
    with zipfile.ZipFile(filename, mode="r") as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jlamb/mambaforge/envs/pydistcheck-dev/lib/python3.11/zipfile.py", line 1302, in __init__
    self._RealGetContents()
  File "/Users/jlamb/mambaforge/envs/pydistcheck-dev/lib/python3.11/zipfile.py", line 1369, in _RealGetContents
    raise BadZipFile("File is not a zip file")
zipfile.BadZipFile: File is not a zip file
```

This PR catches that situation, and raises a `pydistcheck`-controlled more informative error instead.

As of this PR:

```shell
pydistcheck ./README.md
```

```text
==================== running pydistcheck ====================

checking './README.md'
error: File './README.md' does not appear to be a Python package distribution in one of the formats supported by 'pydistcheck'. Supported formats: .conda, .tar.bz2, .tar.gz, .whl, .zip
```
