### PR TITLE
[ci] enforce flake8-pyi checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,8 @@ select = [
     "PGH",
     # pylint
     "PL",
+    # flake8-pyi
+    "PYI",
     # flake8-return
     "RET",
     # ruff-exclusive checks

--- a/src/pydistcheck/utils.py
+++ b/src/pydistcheck/utils.py
@@ -3,7 +3,7 @@ miscellaneous helper classes and functions that are
 not specific to package distributions
 """
 
-from typing import Any, Tuple
+from typing import Tuple
 
 _UNIT_TO_NUM_BYTES = {"B": 1, "K": 1024, "M": 1024**2, "G": 1024**3}
 
@@ -37,7 +37,7 @@ class _FileSize:
     def total_size_bytes(self) -> int:
         return int(self._num * _UNIT_TO_NUM_BYTES[self._unit_str])
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, type(self)) and self.total_size_bytes == other.total_size_bytes
 
     def __ge__(self, other: "_FileSize") -> bool:
@@ -52,7 +52,7 @@ class _FileSize:
     def __lt__(self, other: "_FileSize") -> bool:
         return self.total_size_bytes < other.total_size_bytes
 
-    def __ne__(self, other: Any) -> bool:
+    def __ne__(self, other: object) -> bool:
         return not self == other
 
     def __str__(self) -> str:


### PR DESCRIPTION
Fixes these things found by `flake8-pyi` (via `ruff`):

```text
src/pydistcheck/utils.py:40:29: PYI032 [*] Prefer `object` to `Any` for the second parameter to `__eq__`
src/pydistcheck/utils.py:55:29: PYI032 [*] Prefer `object` to `Any` for the second parameter to `__ne__`
```

From the `ruff` docs:

> The Python documentation recommends the use of `object` to "indicate that a value could be any type in a typesafe manner", while `Any` should be used to "indicate that a value is dynamically typed."

> The semantics of `__eq__` and `__ne__` are such that the obj parameter should be any type, as opposed to a dynamically typed value. Therefore, the object type annotation is more appropriate.

([link](https://docs.astral.sh/ruff/rules/any-eq-ne-annotation/))