### PR TITLE
make --inspect file sizes consistent with other output

### DIFF
--- a/src/pydistcheck/distribution_summary.py
+++ b/src/pydistcheck/distribution_summary.py
@@ -167,8 +167,8 @@ class _DistributionSummary:
         Aggregate file sizes in a distribution by extension.
 
         :return: An OrderedDict where keys are file extensions and values are the total size in
-                 bytes occupied by such files in the distribution. Sorted in descending
-                 order by size.
+                 bytes (uncompressed) occupied by such files in the distribution.
+                 Sorted in descending order by size.
         """
         summary_dict = {
             file_extension: sum(f.uncompressed_size_bytes for f in files)

--- a/src/pydistcheck/inspect.py
+++ b/src/pydistcheck/inspect.py
@@ -26,7 +26,7 @@ def inspect_distribution(summary: "_DistributionSummary") -> None:
     print("size by extension")
     for extension, size in summary.size_by_file_extension.items():
         size_pct = size / summary.uncompressed_size_bytes
-        print(f"  * {extension} - {round(size / 1024.0, 1)}K ({round(size_pct * 100, 1)}%)")
+        print(f"  * {extension} - {_FileSize(size, 'B')} ({round(size_pct * 100, 1)}%)")
 
     largest_files = summary.get_largest_files(n=5)
     print("largest files")


### PR DESCRIPTION
Consider the following:

```shell
 pydistcheck --inspect ./downloads/linux-64-pytorch-2.2.0-py3.10_cpu_0.tar.bz2
```

```text
----- package inspection summary -----
file size
  * compressed size: 79.4M
  * uncompressed size: 0.4G
  * compression space saving: 79.3%
contents
  * directories: 0
  * files: 12076 (11 compiled)
size by extension
  * .so - 298893.6K (76.1%)
  * .py - 25532.7K (6.5%)
  * .h - 25511.6K (6.5%)
  * .pyc - 19139.5K (4.9%)
  * .txt - 6748.1K (1.7%)
  * no-extension - 6236.5K (1.6%)
  * .0 - 5213.9K (1.3%)
  * .json - 3005.1K (0.8%)
  * .yaml - 742.5K (0.2%)
  * .pyi - 626.9K (0.2%)
  * .cuh - 600.7K (0.2%)
...
largest files
  * (0.3G) lib/python3.10/site-packages/torch/lib/libtorch_cpu.so
  * (22.1M) lib/python3.10/site-packages/torch/lib/libtorch_python.so
  * (6.6M) lib/python3.10/site-packages/torch-2.2.0-py3.10.egg-info/SOURCES.txt
  * (5.1M) lib/python3.10/site-packages/torch/bin/protoc-3.13.0.0
  * (5.1M) lib/python3.10/site-packages/torch/bin/protoc
```

I found those things like `298893.6K` very hard to read. As of this PR, that'll look like this instead:

```shell
----- package inspection summary -----
file size
  * compressed size: 79.4M
  * uncompressed size: 0.4G
  * compression space saving: 79.3%
contents
  * directories: 0
  * files: 12076 (11 compiled)
size by extension
  * .so - 0.3G (76.1%)
  * .py - 24.9M (6.5%)
  * .h - 24.9M (6.5%)
  * .pyc - 18.7M (4.9%)
  * .txt - 6.6M (1.7%)
  * no-extension - 6.1M (1.6%)
  * .0 - 5.1M (1.3%)
  * .json - 2.9M (0.8%)
  * .yaml - 0.7M (0.2%)
  * .pyi - 0.6M (0.2%)
  * .cuh - 0.6M (0.2%)
...
largest files
  * (0.3G) lib/python3.10/site-packages/torch/lib/libtorch_cpu.so
  * (22.1M) lib/python3.10/site-packages/torch/lib/libtorch_python.so
  * (6.6M) lib/python3.10/site-packages/torch-2.2.0-py3.10.egg-info/SOURCES.txt
  * (5.1M) lib/python3.10/site-packages/torch/bin/protoc-3.13.0.0
  * (5.1M) lib/python3.10/site-packages/torch/bin/protoc
```
