### PR TITLE
[ci] another upload-artifact fix

### DIFF
--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -65,7 +65,11 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: sdist
+          path: dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel
           path: dist
       - name: upload distributions to release
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
Fixes this: https://github.com/jameslamb/pydistcheck/actions/runs/7946995638/job/21695328634

```text
Run actions/download-artifact@v4
Downloading single artifact
Error: Unable to download artifact(s): Artifact not found for name: artifact
        Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact.
        For more information, visit the GitHub Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md
```