### PR TITLE
[ci] use pre-commit to run some autoformatting and linting

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,11 +24,9 @@ jobs:
           conda install \
             --yes \
             -c conda-forge \
-              black \
-              isort \
               'mypy>=0.931' \
+              pre-commit \
               requests \
-              ruff \
               shellcheck \
               types-requests \
               yamllint

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,7 +34,7 @@ jobs:
           #########
           # macOS #
           #########
-          - os: macOS-latest
+          - os: macOS-13
             python_version: '3.8'
           - os: macOS-latest
             python_version: '3.10'
@@ -132,7 +132,7 @@ jobs:
         include:
           - os: ubuntu-latest
             python_version: '3.11'
-          - os: macOS-latest
+          - os: macOS-13
             python_version: '3.10'
     steps:
       - name: check out repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-toml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort (python)
+        args: ["--settings-path", "pyproject.toml"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        args: ["--config-file", "pyproject.toml"]
+        exclude: "tests"
+        additional_dependencies:
+          - types-requests
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.4.4
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: ["--config", "pyproject.toml"]
+      # Run the formatter.
+      - id: ruff-format
+        args: ["--config", "pyproject.toml"]
+        types_or: [python, jupyter]

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,6 @@ format:
 		--indent 4 \
 		--space-redirects \
 		./bin
-	isort .
-	black .
 
 .PHONY: install
 install:
@@ -44,6 +42,7 @@ install:
 
 .PHONY: lint
 lint:
+	pre-commit run --all-files
 	shfmt \
 		-d \
 		-i 4 \
@@ -52,12 +51,6 @@ lint:
 	shellcheck \
 		--exclude=SC2002 \
 		bin/*.sh
-	black \
-		--check \
-		.
-	ruff check .
-	mypy ./src
-	mypy ./tests/data
 	yamllint \
 		--strict \
 		-d '{extends: default, rules: {braces: {max-spaces-inside: 1}, truthy: {check-keys: false}, line-length: {max: 120}}}' \

--- a/bin/get-conda-release-files.py
+++ b/bin/get-conda-release-files.py
@@ -50,7 +50,9 @@ for file_type in files_by_type:
     output_file = os.path.join(OUTPUT_DIR, sample_release.filename)
     print(f"Downloading '{sample_release.filename}'")
     res = requests.get(
-        url=sample_release.url, headers={"Accept": "application/octet-stream"}, timeout=30
+        url=sample_release.url,
+        headers={"Accept": "application/octet-stream"},
+        timeout=30,
     )
     res.raise_for_status()
     with open(output_file, "wb") as f:

--- a/bin/get-pypi-files.py
+++ b/bin/get-pypi-files.py
@@ -62,7 +62,9 @@ for file_type in files_by_type:
     output_file = os.path.join(OUTPUT_DIR, sample_release.filename)
     print(f"Downloading '{sample_release.filename}'")
     res = requests.get(
-        url=sample_release.url, headers={"Accept": "application/octet-stream"}, timeout=30
+        url=sample_release.url,
+        headers={"Accept": "application/octet-stream"},
+        timeout=30,
     )
     res.raise_for_status()
     with open(output_file, "wb") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,9 +67,6 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.black]
-line-length = 100
-
 [tool.isort]
 line_length = 100
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ profile = "black"
 [tool.mypy]
 exclude = 'docs/conf\.py$|build/*'
 ignore_missing_imports = true
+mypy_path = "./src:./tests/data"
 strict = true
 
 [tool.ruff]
@@ -135,6 +136,10 @@ select = [
     "PLR0912",
     # Too many statements
     "PLR0915"
+]
+"src/pydistcheck/distribution_summary.py" = [
+    # Too many branches
+    "PLR0912"
 ]
 "tests/*" = [
     # (flake8-bugbear) Found useless expression

--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -33,7 +33,9 @@ ALL_CHECKS = {
 class _CheckProtocol(Protocol):
     check_name: str
 
-    def __call__(self, distro_summary: _DistributionSummary) -> List[str]:  # pragma: no cover
+    def __call__(
+        self, distro_summary: _DistributionSummary
+    ) -> List[str]:  # pragma: no cover
         ...
 
 
@@ -42,7 +44,9 @@ class _CompiledObjectsDebugSymbolCheck(_CheckProtocol):
 
     def __call__(self, distro_summary: _DistributionSummary) -> List[str]:
         out: List[str] = []
-        compiled_object_paths = [file_info.name for file_info in distro_summary.compiled_objects]
+        compiled_object_paths = [
+            file_info.name for file_info in distro_summary.compiled_objects
+        ]
         if not compiled_object_paths:
             return out
 
@@ -96,7 +100,9 @@ class _DistroTooLargeUnCompressedCheck(_CheckProtocol):
     def __call__(self, distro_summary: _DistributionSummary) -> List[str]:
         out: List[str] = []
         max_size = _FileSize(num=self.max_allowed_size_bytes, unit_str="B")
-        actual_size = _FileSize(num=distro_summary.uncompressed_size_bytes, unit_str="B")
+        actual_size = _FileSize(
+            num=distro_summary.uncompressed_size_bytes, unit_str="B"
+        )
         if actual_size > max_size:
             msg = (
                 f"[{self.check_name}] Uncompressed size {actual_size} is larger "
@@ -155,7 +161,9 @@ class _NonAsciiCharacterCheck(_CheckProtocol):
         out: List[str] = []
         for file_path in distro_summary.all_paths:
             if not file_path.isascii():
-                ascii_converted_str = file_path.encode("ascii", "replace").decode("ascii")
+                ascii_converted_str = file_path.encode("ascii", "replace").decode(
+                    "ascii"
+                )
                 msg = (
                     f"[{self.check_name}] Found file path containing non-ASCII characters: "
                     f"'{ascii_converted_str}'"
@@ -210,7 +218,9 @@ class _UnexpectedFilesCheck(_CheckProtocol):
     check_name = "unexpected-files"
 
     def __init__(
-        self, unexpected_directory_patterns: List[str], unexpected_file_patterns: List[str]
+        self,
+        unexpected_directory_patterns: List[str],
+        unexpected_file_patterns: List[str],
     ):
         self.unexpected_directory_patterns = unexpected_directory_patterns
         self.unexpected_file_patterns = unexpected_file_patterns

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -33,20 +33,20 @@ class ExitCodes:
     UNSUPPORTED_FILE_TYPE = 2
 
 
-@click.command()
-@click.argument(
+@click.command()  # type: ignore[misc]
+@click.argument(  # type: ignore[misc]
     "filepaths",
     type=click.Path(exists=True),
     nargs=-1,
 )
-@click.option(
+@click.option(  # type: ignore[misc]
     "--version",
     is_flag=True,
     show_default=False,
     default=False,
     help="Print the version of pydistcheck and exit.",
 )
-@click.option(
+@click.option(  # type: ignore[misc]
     "--config",
     type=click.Path(exists=True),
     default=None,
@@ -55,7 +55,7 @@ class ExitCodes:
         "If provided, pyproject.toml will be ignored."
     ),
 )
-@click.option(
+@click.option(  # type: ignore[misc]
     "--ignore",
     type=str,
     default=_Config.ignore,
@@ -64,21 +64,21 @@ class ExitCodes:
         "``distro-too-large-compressed,path-contains-spaces``."
     ),
 )
-@click.option(
+@click.option(  # type: ignore[misc]
     "--inspect",
     is_flag=True,
     show_default=False,
     default=_Config.inspect,
     help="print diagnostic information about the distribution",
 )
-@click.option(
+@click.option(  # type: ignore[misc]
     "--max-allowed-files",
     default=_Config.max_allowed_files,
     show_default=True,
     type=int,
     help="maximum number of files allowed in the distribution",
 )
-@click.option(
+@click.option(  # type: ignore[misc]
     "--max-allowed-size-compressed",
     default=_Config.max_allowed_size_compressed,
     show_default=True,
@@ -92,7 +92,7 @@ class ExitCodes:
         "  - G = gigabytes"
     ),
 )
-@click.option(
+@click.option(  # type: ignore[misc]
     "--max-allowed-size-uncompressed",
     default=_Config.max_allowed_size_uncompressed,
     show_default=True,
@@ -106,7 +106,7 @@ class ExitCodes:
         "  - G = gigabytes"
     ),
 )
-@click.option(
+@click.option(  # type: ignore[misc]
     "--unexpected-directory-patterns",
     default=_Config.unexpected_directory_patterns,
     show_default=True,
@@ -117,7 +117,7 @@ class ExitCodes:
         "by ``fnmatch.fnmatchcase()``. See https://docs.python.org/3/library/fnmatch.html."
     ),
 )
-@click.option(
+@click.option(  # type: ignore[misc]
     "--unexpected-file-patterns",
     default=_Config.unexpected_file_patterns,
     show_default=True,
@@ -182,7 +182,9 @@ def check(  # noqa: PLR0913
         # converting to list + sorting here so outputs are deterministic
         # (since sets don't guarantee ordering)
         error_str = ",".join(sorted(unrecognized_checks))
-        print(f"ERROR: found the following unrecognized checks passed via '--ignore': {error_str}")
+        print(
+            f"ERROR: found the following unrecognized checks passed via '--ignore': {error_str}"
+        )
         sys.exit(1)
 
     checks = [

--- a/src/pydistcheck/config.py
+++ b/src/pydistcheck/config.py
@@ -73,7 +73,9 @@ class _Config:
     def __setattr__(self, name: str, value: Any) -> None:
         attr_name = name.replace("-", "_")
         if attr_name not in _ALLOWED_CONFIG_VALUES:
-            raise ValueError(f"Configuration value '{name}' is not recognized by pydistcheck")
+            raise ValueError(
+                f"Configuration value '{name}' is not recognized by pydistcheck"
+            )
         object.__setattr__(self, attr_name, value)
 
     def update_from_dict(self, input_dict: Dict[str, Any]) -> "_Config":

--- a/src/pydistcheck/distribution_summary.py
+++ b/src/pydistcheck/distribution_summary.py
@@ -40,7 +40,9 @@ class _DistributionSummary:
                 for tar_info in tf.getmembers():
                     if tar_info.isfile():
                         files.append(
-                            _FileInfo.from_tarfile_member(archive_file=tf, tar_info=tar_info)
+                            _FileInfo.from_tarfile_member(
+                                archive_file=tf, tar_info=tar_info
+                            )
                         )
                     else:
                         directories.append(_DirectoryInfo(name=tar_info.name))
@@ -49,7 +51,9 @@ class _DistributionSummary:
                 for tar_info in tf.getmembers():
                     if tar_info.isfile():
                         files.append(
-                            _FileInfo.from_tarfile_member(archive_file=tf, tar_info=tar_info)
+                            _FileInfo.from_tarfile_member(
+                                archive_file=tf, tar_info=tar_info
+                            )
                         )
                     else:
                         directories.append(_DirectoryInfo(name=tar_info.name))
@@ -61,7 +65,9 @@ class _DistributionSummary:
             #      - 'pkg-*.tar.zst'
             #
             # ref: https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/packages.html#conda-file-format
-            with zipfile.ZipFile(filename, mode="r") as f, TemporaryDirectory() as tmp_dir:
+            with zipfile.ZipFile(
+                filename, mode="r"
+            ) as f, TemporaryDirectory() as tmp_dir:
                 for zip_info in f.infolist():
                     # case 1 - is a directory
                     if zip_info.is_dir():
@@ -69,7 +75,9 @@ class _DistributionSummary:
                     # case 2 - is a file but not one of the zstandard-compressed ones
                     elif not zip_info.filename.lower().endswith("tar.zst"):
                         files.append(
-                            _FileInfo.from_zipfile_member(archive_file=f, zip_info=zip_info)
+                            _FileInfo.from_zipfile_member(
+                                archive_file=f, zip_info=zip_info
+                            )
                         )
                     # case 3 - one of the zstandard-compressed archives
                     else:
@@ -81,9 +89,12 @@ class _DistributionSummary:
                             zf.extractall(path=tmp_dir, members=[zip_info.filename])
 
                             # decompress the .tar.zst to just .tar
-                            decompressed_tar_path = full_path.lower().replace(".tar.zst", ".tar")
+                            decompressed_tar_path = full_path.lower().replace(
+                                ".tar.zst", ".tar"
+                            )
                             _decompress_zstd_archive(
-                                tar_zst_file=full_path, decompressed_tar_path=decompressed_tar_path
+                                tar_zst_file=full_path,
+                                decompressed_tar_path=decompressed_tar_path,
                             )
 
                         # do tarfile things
@@ -96,14 +107,18 @@ class _DistributionSummary:
                                         )
                                     )
                                 else:
-                                    directories.append(_DirectoryInfo(name=tar_info.name))
+                                    directories.append(
+                                        _DirectoryInfo(name=tar_info.name)
+                                    )
         elif archive_format == _ArchiveFormat.ZIP:
             # assume anything else can be opened with zipfile
             with zipfile.ZipFile(filename, mode="r") as f:
                 for zip_info in f.infolist():
                     if not zip_info.is_dir():
                         files.append(
-                            _FileInfo.from_zipfile_member(archive_file=f, zip_info=zip_info)
+                            _FileInfo.from_zipfile_member(
+                                archive_file=f, zip_info=zip_info
+                            )
                         )
                     else:
                         directories.append(_DirectoryInfo(name=zip_info.filename))
@@ -155,7 +170,9 @@ class _DistributionSummary:
         return len(self.files)
 
     def get_largest_files(self, n: int) -> List[_FileInfo]:
-        return sorted(self.files, key=lambda f: f.uncompressed_size_bytes, reverse=True)[:n]
+        return sorted(
+            self.files, key=lambda f: f.uncompressed_size_bytes, reverse=True
+        )[:n]
 
     @property
     def uncompressed_size_bytes(self) -> int:

--- a/src/pydistcheck/file_utils.py
+++ b/src/pydistcheck/file_utils.py
@@ -215,7 +215,9 @@ def _extract_subset_of_files_from_archive(
             # do tarfile things
             with tarfile.open(decompressed_tar_path, mode="r") as tf:
                 files_to_extract = [
-                    tar_info for tar_info in tf.getmembers() if tar_info.name in relative_paths
+                    tar_info
+                    for tar_info in tf.getmembers()
+                    if tar_info.name in relative_paths
                 ]
                 tf.extractall(
                     path=out_dir,

--- a/src/pydistcheck/inspect.py
+++ b/src/pydistcheck/inspect.py
@@ -16,7 +16,9 @@ def inspect_distribution(summary: "_DistributionSummary") -> None:
     uncompressed_size = _FileSize(summary.uncompressed_size_bytes, "B")
     print(f"  * compressed size: {compressed_size}")
     print(f"  * uncompressed size: {uncompressed_size}")
-    space_saving = 1.0 - (compressed_size.total_size_bytes / uncompressed_size.total_size_bytes)
+    space_saving = 1.0 - (
+        compressed_size.total_size_bytes / uncompressed_size.total_size_bytes
+    )
     print(f"  * compression space saving: {round(100 * space_saving, 1)}%")
 
     print("contents")
@@ -31,4 +33,6 @@ def inspect_distribution(summary: "_DistributionSummary") -> None:
     largest_files = summary.get_largest_files(n=5)
     print("largest files")
     for file_info in largest_files:
-        print(f"  * ({_FileSize(file_info.uncompressed_size_bytes, 'B')}) {file_info.name}")
+        print(
+            f"  * ({_FileSize(file_info.uncompressed_size_bytes, 'B')}) {file_info.name}"
+        )

--- a/src/pydistcheck/shared_lib_utils.py
+++ b/src/pydistcheck/shared_lib_utils.py
@@ -46,7 +46,9 @@ _COMMANDS_TO_PATTERNS = [
 def _look_for_debug_symbols(lib_file: str) -> Tuple[bool, str]:
     for cmd_args, pattern in _COMMANDS_TO_PATTERNS:
         stdout = _run_command(args=[*cmd_args, lib_file])
-        contains_debug_symbols = any(bool(re.search(pattern, x)) for x in stdout.split("\n"))
+        contains_debug_symbols = any(
+            bool(re.search(pattern, x)) for x in stdout.split("\n")
+        )
         if contains_debug_symbols:
             return True, " ".join(cmd_args)
     # if you get here, no debug symbols were found by any tools
@@ -55,7 +57,9 @@ def _look_for_debug_symbols(lib_file: str) -> Tuple[bool, str]:
 
 def _get_symbols(cmd_args: List[str], lib_file: str) -> str:
     syms = _run_command(args=[*cmd_args, lib_file])
-    return "\n".join([line for line in syms.split("\n") if not (" a " in line or "\ta\t" in line)])
+    return "\n".join(
+        [line for line in syms.split("\n") if not (" a " in line or "\ta\t" in line)]
+    )
 
 
 def _nm_reports_debug_symbols(tool_name: str, lib_file: str) -> Tuple[bool, str]:
@@ -65,7 +69,6 @@ def _nm_reports_debug_symbols(tool_name: str, lib_file: str) -> Tuple[bool, str]
 
 
 def _file_has_debug_symbols(file_absolute_path: str) -> Tuple[bool, str]:
-
     # test with tools that produce debug symbols that can be matched with a regex
     has_debug_symbols, cmd_str = _look_for_debug_symbols(lib_file=file_absolute_path)
     if has_debug_symbols:

--- a/src/pydistcheck/utils.py
+++ b/src/pydistcheck/utils.py
@@ -38,7 +38,10 @@ class _FileSize:
         return int(self._num * _UNIT_TO_NUM_BYTES[self._unit_str])
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, type(self)) and self.total_size_bytes == other.total_size_bytes
+        return (
+            isinstance(other, type(self))
+            and self.total_size_bytes == other.total_size_bytes
+        )
 
     def __ge__(self, other: "_FileSize") -> bool:
         return self.total_size_bytes >= other.total_size_bytes

--- a/tests/data/baseballmetrics/CMakeLists.txt
+++ b/tests/data/baseballmetrics/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
     set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
 endif()
 
-# install lib_baseballmetrics to 
+# install lib_baseballmetrics to
 install(
   TARGETS _baseballmetrics
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/tests/data/baseballmetrics/baseballmetrics/_shared_lib.py
+++ b/tests/data/baseballmetrics/baseballmetrics/_shared_lib.py
@@ -8,5 +8,10 @@ else:
     _shlib_ext = "so"
 
 _LIB = ctypes.cdll.LoadLibrary(
-    str(Path(__file__).absolute().parents[1].joinpath(f"lib/lib_baseballmetrics.{_shlib_ext}"))
+    str(
+        Path(__file__)
+        .absolute()
+        .parents[1]
+        .joinpath(f"lib/lib_baseballmetrics.{_shlib_ext}")
+    )
 )

--- a/tests/data/baseballmetrics/baseballmetrics/metrics.py
+++ b/tests/data/baseballmetrics/baseballmetrics/metrics.py
@@ -5,5 +5,7 @@ from baseballmetrics._shared_lib import _LIB
 
 def batting_average(hits: int, at_bats: int) -> float:
     ret = ctypes.c_double(0.0)
-    _LIB.BattingAverage(ctypes.c_int32(hits), ctypes.c_int32(at_bats), ctypes.byref(ret))
+    _LIB.BattingAverage(
+        ctypes.c_int32(hits), ctypes.c_int32(at_bats), ctypes.byref(ret)
+    )
     return ret.value

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,10 @@ BASE_PACKAGES = [
     "base-package-0.1.0.tar.gz",
     "base-package-0.1.0.zip",
 ]
-PROBLEMATIC_PACKAGES = ["problematic-package-0.1.0.tar.gz", "problematic-package-0.1.0.zip"]
+PROBLEMATIC_PACKAGES = [
+    "problematic-package-0.1.0.tar.gz",
+    "problematic-package-0.1.0.zip",
+]
 MACOS_SUFFIX = "macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_5_x86_64.whl"
 MANYLINUX_SUFFIX = "manylinux_2_28_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.whl"
 BASEBALL_PACKAGES = [
@@ -35,7 +38,9 @@ PACKAGES_WITH_DEBUG_SYMBOLS = [
 TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 
-def _assert_log_matches_pattern(result: Result, pattern: str, num_times: int = 1) -> None:
+def _assert_log_matches_pattern(
+    result: Result, pattern: str, num_times: int = 1
+) -> None:
     log_lines = result.output.split("\n")
     match_results = [bool(re.search(pattern, log_line)) for log_line in log_lines]
     num_matches_found = sum(match_results)
@@ -198,7 +203,10 @@ def test_check_respects_ignore_with_multiple_checks(distro_file):
 def test_check_fails_with_expected_error_if_one_check_is_unrecognized(distro_file):
     result = CliRunner().invoke(
         check,
-        [os.path.join(TEST_DATA_DIR, distro_file), "--ignore=too-many-files,random-nonsense"],
+        [
+            os.path.join(TEST_DATA_DIR, distro_file),
+            "--ignore=too-many-files,random-nonsense",
+        ],
     )
     assert result.exit_code == 1
     _assert_log_matches_pattern(
@@ -211,7 +219,9 @@ def test_check_fails_with_expected_error_if_one_check_is_unrecognized(distro_fil
 
 
 @pytest.mark.parametrize("distro_file", BASE_PACKAGES)
-def test_check_fails_with_expected_error_if_multiple_checks_are_unrecognized(distro_file):
+def test_check_fails_with_expected_error_if_multiple_checks_are_unrecognized(
+    distro_file,
+):
     result = CliRunner().invoke(
         check,
         [
@@ -258,7 +268,10 @@ def test_check_respects_max_allowed_size_compressed(size_str, distro_file):
     runner = CliRunner()
     result = runner.invoke(
         check,
-        [os.path.join(TEST_DATA_DIR, distro_file), f"--max-allowed-size-compressed={size_str}"],
+        [
+            os.path.join(TEST_DATA_DIR, distro_file),
+            f"--max-allowed-size-compressed={size_str}",
+        ],
     )
     assert result.exit_code == 1
 
@@ -287,7 +300,10 @@ def test_check_respects_max_allowed_size_uncompressed(size_str, distro_file):
     runner = CliRunner()
     result = runner.invoke(
         check,
-        [os.path.join(TEST_DATA_DIR, distro_file), f"--max-allowed-size-uncompressed={size_str}"],
+        [
+            os.path.join(TEST_DATA_DIR, distro_file),
+            f"--max-allowed-size-uncompressed={size_str}",
+        ],
     )
     assert result.exit_code == 1
 
@@ -306,7 +322,9 @@ def test_check_prefers_pyproject_toml_to_defaults(distro_file, tmp_path):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
         with open("pyproject.toml", "w") as f:
-            f.write("[tool.pylint]\n[tool.pydistcheck]\nmax_allowed_size_uncompressed = '7B'\n")
+            f.write(
+                "[tool.pylint]\n[tool.pydistcheck]\nmax_allowed_size_uncompressed = '7B'\n"
+            )
         result = runner.invoke(
             check,
             [os.path.join(TEST_DATA_DIR, distro_file)],
@@ -349,14 +367,21 @@ def test_check_handles_ignore_list_in_pyproject_toml_correctly(distro_file, tmp_
 
 
 @pytest.mark.parametrize("distro_file", BASE_PACKAGES)
-def test_check_prefers_keyword_args_to_pyproject_toml_and_defaults(distro_file, tmp_path):
+def test_check_prefers_keyword_args_to_pyproject_toml_and_defaults(
+    distro_file, tmp_path
+):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
         with open("pyproject.toml", "w") as f:
-            f.write("[tool.pylint]\n[tool.pydistcheck]\nmax_allowed_size_uncompressed = '7B'\n")
+            f.write(
+                "[tool.pylint]\n[tool.pydistcheck]\nmax_allowed_size_uncompressed = '7B'\n"
+            )
         result = runner.invoke(
             check,
-            [os.path.join(TEST_DATA_DIR, distro_file), "--max-allowed-size-uncompressed=123B"],
+            [
+                os.path.join(TEST_DATA_DIR, distro_file),
+                "--max-allowed-size-uncompressed=123B",
+            ],
         )
 
     assert result.exit_code == 1
@@ -375,12 +400,16 @@ def test_check_prefers_custom_toml_file_to_root_pyproject_toml(distro_file, tmp_
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
         with open("pyproject.toml", "w") as f:
-            f.write("[tool.pylint]\n[tool.pydistcheck]\nmax_allowed_size_uncompressed = '10GB'\n")
+            f.write(
+                "[tool.pylint]\n[tool.pydistcheck]\nmax_allowed_size_uncompressed = '10GB'\n"
+            )
         other_dir = os.path.join(tmp_path, "cool-files")
         other_config = os.path.join(other_dir, "stuff.toml")
         os.mkdir(other_dir)
         with open(other_config, "w") as f:
-            f.write("[tool.pylint]\n[tool.pydistcheck]\nmax_allowed_size_uncompressed = '7B'\n")
+            f.write(
+                "[tool.pylint]\n[tool.pydistcheck]\nmax_allowed_size_uncompressed = '7B'\n"
+            )
         result = runner.invoke(
             check,
             [os.path.join(TEST_DATA_DIR, distro_file), f"--config={other_config}"],
@@ -415,7 +444,9 @@ def test_files_only_differ_by_case_works(distro_file):
             r",problematic\-package\-0\.1\.0/problematic_package/question\.py"
         ),
     )
-    _assert_log_matches_pattern(result=result, pattern=r"errors found while checking\: [0-9]{1}")
+    _assert_log_matches_pattern(
+        result=result, pattern=r"errors found while checking\: [0-9]{1}"
+    )
 
 
 @pytest.mark.parametrize("distro_file", PROBLEMATIC_PACKAGES)
@@ -442,7 +473,9 @@ def test_mixed_file_extension_use_works(distro_file):
         ),
     )
 
-    _assert_log_matches_pattern(result=result, pattern=r"errors found while checking\: [0-9]{1}")
+    _assert_log_matches_pattern(
+        result=result, pattern=r"errors found while checking\: [0-9]{1}"
+    )
 
 
 @pytest.mark.parametrize("distro_file", PROBLEMATIC_PACKAGES)
@@ -465,7 +498,9 @@ def test_path_contains_non_ascii_characters_works(distro_file):
         ),
     )
 
-    _assert_log_matches_pattern(result=result, pattern=r"errors found while checking\: [0-9]{1}")
+    _assert_log_matches_pattern(
+        result=result, pattern=r"errors found while checking\: [0-9]{1}"
+    )
 
 
 @pytest.mark.parametrize("distro_file", PROBLEMATIC_PACKAGES)
@@ -511,7 +546,9 @@ def test_path_contains_spaces_works(distro_file):
         ),
     )
 
-    _assert_log_matches_pattern(result=result, pattern=r"errors found while checking\: [0-9]{1}")
+    _assert_log_matches_pattern(
+        result=result, pattern=r"errors found while checking\: [0-9]{1}"
+    )
 
 
 @pytest.mark.parametrize("distro_file", PROBLEMATIC_PACKAGES)
@@ -557,18 +594,24 @@ def test_unexpected_files_check_works(distro_file):
         ),
     )
 
-    _assert_log_matches_pattern(result=result, pattern=r"errors found while checking\: [0-9]{1}")
+    _assert_log_matches_pattern(
+        result=result, pattern=r"errors found while checking\: [0-9]{1}"
+    )
 
 
 @pytest.mark.parametrize("distro_file", PROBLEMATIC_PACKAGES)
-def test_cli_raises_exactly_the_expected_number_of_errors_for_the_problematic_package(distro_file):
+def test_cli_raises_exactly_the_expected_number_of_errors_for_the_problematic_package(
+    distro_file,
+):
     runner = CliRunner()
     result = runner.invoke(
         check,
         [os.path.join(TEST_DATA_DIR, distro_file)],
     )
     assert result.exit_code == 1
-    _assert_log_matches_pattern(result=result, pattern=r"errors found while checking\: 12$")
+    _assert_log_matches_pattern(
+        result=result, pattern=r"errors found while checking\: 12$"
+    )
 
 
 @pytest.mark.parametrize("distro_file", PACKAGES_WITH_DEBUG_SYMBOLS)
@@ -617,7 +660,12 @@ def test_debug_symbols_check_works(distro_file):
 def test_inspect_runs_before_checks(distro_file):
     runner = CliRunner()
     result = runner.invoke(
-        check, ["--inspect", "--max-allowed-files=1", os.path.join(TEST_DATA_DIR, distro_file)]
+        check,
+        [
+            "--inspect",
+            "--max-allowed-files=1",
+            os.path.join(TEST_DATA_DIR, distro_file),
+        ],
     )
     assert result.exit_code == 1
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,7 +45,9 @@ def test_update_from_dict_raises_exception_for_first_bad_value_encountered(base_
         base_config.update_from_dict({"a": 7, "b": 8, "inspect": False})
 
 
-def test_update_from_dict_works_even_if_dict_does_not_include_all_config_values(base_config):
+def test_update_from_dict_works_even_if_dict_does_not_include_all_config_values(
+    base_config,
+):
     assert base_config.inspect is False
     base_config.update_from_dict({"inspect": True})
     assert base_config.inspect is True
@@ -65,7 +67,9 @@ def test_update_from_dict_works_when_changing_all_values(base_config):
         "unexpected_directory_patterns": "*/tests",
         "unexpected_file_patterns": "*.xlsx,data/*.csv",
     }
-    assert set(patch_dict.keys()) == _ALLOWED_CONFIG_VALUES, "this test needs to be updated"
+    assert (
+        set(patch_dict.keys()) == _ALLOWED_CONFIG_VALUES
+    ), "this test needs to be updated"
     base_config.update_from_dict(patch_dict)
     assert base_config.inspect is True
     assert base_config.max_allowed_files == 8
@@ -81,7 +85,9 @@ def test_update_from_toml_silently_returns_self_if_file_does_not_exist(base_conf
     assert out == original_config
 
 
-def test_update_from_toml_works_for_files_with_no_pydistcheck_configuration(base_config, tmpdir):
+def test_update_from_toml_works_for_files_with_no_pydistcheck_configuration(
+    base_config, tmpdir
+):
     original_config = deepcopy(base_config)
     temp_file = os.path.join(tmpdir, f"{uuid.uuid4().hex}.toml")
     with open(temp_file, "w") as f:
@@ -90,7 +96,9 @@ def test_update_from_toml_works_for_files_with_no_pydistcheck_configuration(base
     assert base_config == original_config
 
 
-def test_update_from_toml_works_for_files_with_empty_pydistcheck_configuration(base_config, tmpdir):
+def test_update_from_toml_works_for_files_with_empty_pydistcheck_configuration(
+    base_config, tmpdir
+):
     original_config = deepcopy(base_config)
     temp_file = os.path.join(tmpdir, f"{uuid.uuid4().hex}.toml")
     with open(temp_file, "w") as f:
@@ -102,7 +110,9 @@ def test_update_from_toml_works_for_files_with_empty_pydistcheck_configuration(b
 @pytest.mark.parametrize(
     "config_key", ["max_allowed_size_compressed", "max-allowed-size_compressed"]
 )
-def test_update_from_toml_works_with_underscores_and_hyphens(base_config, tmpdir, config_key):
+def test_update_from_toml_works_with_underscores_and_hyphens(
+    base_config, tmpdir, config_key
+):
     temp_file = os.path.join(tmpdir, f"{uuid.uuid4().hex}.toml")
     with open(temp_file, "w") as f:
         f.write(f"[tool.pylint]\n[tool.pydistcheck]\n{config_key} = '2.5G'\n")
@@ -111,7 +121,9 @@ def test_update_from_toml_works_with_underscores_and_hyphens(base_config, tmpdir
 
 
 @pytest.mark.parametrize("use_hyphens", [True, False])
-def test_update_from_toml_works_with_all_config_values(base_config, tmpdir, use_hyphens):
+def test_update_from_toml_works_with_all_config_values(
+    base_config, tmpdir, use_hyphens
+):
     temp_file = os.path.join(tmpdir, f"{uuid.uuid4().hex}.toml")
     patch_dict = {
         "ignore": "[\n'path-contains-spaces',\n'too-many-files'\n]",
@@ -122,7 +134,9 @@ def test_update_from_toml_works_with_all_config_values(base_config, tmpdir, use_
         "unexpected_directory_patterns": "[\n'tests/*'\n]",
         "unexpected_file_patterns": "[\n'*.pq',\n'*/tests/data/*.csv']",
     }
-    assert set(patch_dict.keys()) == _ALLOWED_CONFIG_VALUES, "this test needs to be updated"
+    assert (
+        set(patch_dict.keys()) == _ALLOWED_CONFIG_VALUES
+    ), "this test needs to be updated"
     if use_hyphens:
         patch_dict = {k.replace("_", "-"): v for k, v in patch_dict.items()}
     with open(temp_file, "w") as f:

--- a/tests/test_distribution_summary.py
+++ b/tests/test_distribution_summary.py
@@ -79,7 +79,10 @@ def test_distribution_summary_basically_works(distro_file):
 
     # files_by_extension makes sense
     assert ds.files_by_extension.keys() == ds.size_by_file_extension.keys()
-    assert sum(len(file_list) for file_list in ds.files_by_extension.values()) == ds.num_files
+    assert (
+        sum(len(file_list) for file_list in ds.files_by_extension.values())
+        == ds.num_files
+    )
 
     # size_by_file_extension should return results sorted from largest to smallest by file size
     last_size_seen = float("inf")
@@ -100,7 +103,9 @@ def test_distribution_summary_basically_works(distro_file):
 
 
 def test_distribution_summary_get_largest_files_works():
-    ds = _DistributionSummary.from_file(os.path.join(TEST_DATA_DIR, BASE_PACKAGE_SDISTS[0]))
+    ds = _DistributionSummary.from_file(
+        os.path.join(TEST_DATA_DIR, BASE_PACKAGE_SDISTS[0])
+    )
 
     # get_largest_files() should return a non-empty list of _FileInfo objects
     num_files = ds.num_files


### PR DESCRIPTION
Also switches from `black` to `ruff-format` for autoformatting Python code.