### PR TITLE
[ci] update some CI dependencies, add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      ci-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "[ci]"
+    labels:
+      - maintenance

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: run tests
         shell: bash -l {0}
         run: |
-          mamba install \
+          conda install \
             --yes \
               pipx \
               requests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-toml
       - id: end-of-file-fixer

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 ---
 version: 2
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-lts-latest"
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-latest"
   jobs:
     post_create_environment:
       - pip install .

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,10 +4,10 @@ This page describes how to test and develop changes to ``pydistcheck``'s documen
 
 ## Build Locally
 
-To build the documentation locally, create a ``conda`` environment using [`mamba`](https://github.com/mamba-org/mamba).
+To build the documentation locally, create a ``conda`` environment.
 
 ```shell
-mamba env create \
+conda env create \
     -n pydistcheck-docs \
     --file ./env.yml
 ```

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -43,12 +43,6 @@ If you use tools like ``conda`` or ``mamba`` to manage environments, install ``p
 
     conda install -c conda-forge pydistcheck
 
-or
-
-.. code-block:: shell
-
-    mamba install pydistcheck
-
 development version
 *******************
 


### PR DESCRIPTION
* adds configuration to get dependabot to automatically recommend updating third-party GitHub Actions
* changes readthedocs configuration to "latest" types of versions that'll keep automatically updating as readthedocs does
* updates pre-commit versions (ran `pre-commit autoupdate`)
* switches commands from `mamba {cmd}` back to `conda {cmd}`
  - *`conda` now includes `libmamba` as its default solver, no more need to use the `mamba` command*

### References

* https://docs.readthedocs.io/en/latest/config-file/v2.html#build-tools-python
* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
* https://conda.org/blog/2023-11-06-conda-23-10-0-release/