### PR TITLE
add expected-files check, rename '--unexpected-file-patterns' to '--expected-files' (fixes #233)

### DIFF
--- a/bin/check-test-packages.sh
+++ b/bin/check-test-packages.sh
@@ -5,15 +5,15 @@
 
 set -e -u -o pipefail
 
-if [[ $OSTYPE == 'darwin'* ]]; then
+if [[ $OSTYPE =~ [Dd]arwin.* ]]; then
     OS_NAME="macos"
 else
     OS_NAME="linux"
 fi
 
 check_distro() {
-    distro_file=${1}
-    test_code=${2}
+    local distro_file=${1}
+    local test_code=${2}
     echo ""
     echo "checking '${distro_file}'"
     pip uninstall -qq --yes \

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -5,7 +5,7 @@ set -e -u -o pipefail
 echo "running smoke tests"
 
 get-files() {
-    pkg_name=$1
+    local pkg_name=$1
     rm -rf ./smoke-tests
     mkdir -p ./smoke-tests
     echo ""
@@ -15,7 +15,7 @@ get-files() {
 }
 
 get-conda-forge-files() {
-    pkg_name=$1
+    local pkg_name=$1
     mkdir -p ./smoke-tests
     echo ""
     python bin/get-conda-release-files.py \

--- a/docs/_static/defaults.toml
+++ b/docs/_static/defaults.toml
@@ -5,31 +5,31 @@ inspect = false
 max_allowed_files = 2000
 max_allowed_size_compressed = '50M'
 max_allowed_size_uncompressed = '75M'
-unexpected_directory_patterns = [
-    '*/.appveyor',
-    '*/.binder',
-    '*/.circleci',
-    '*/.git',
-    '*/.github',
-    '*/.idea',
-    '*/.pytest_cache',
-    '*/.mypy_cache'
+expected_directories = [
+    '!*/.appveyor',
+    '!*/.binder',
+    '!*/.circleci',
+    '!*/.git',
+    '!*/.github',
+    '!*/.idea',
+    '!*/.pytest_cache',
+    '!*/.mypy_cache'
 ]
-unexpected_file_patterns = [
-    '*/appveyor.yml',
-    '*/.appveyor.yml',
-    '*/azure-pipelines.yml',
-    '*/.azure-pipelines.yml',
-    '*/.cirrus.star',
-    '*/.cirrus.yml',
-    '*/codecov.yml',
-    '*/.codecov.yml',
-    '*/.DS_Store',
-    '*/.gitignore',
-    '*/.gitpod.yml',
-    '*/.hadolint.yaml',
-    '*/.readthedocs.yaml',
-    '*/.travis.yml',
-    '*/vsts-ci.yml',
-    '*/.vsts-ci.yml'
+expected_files = [
+    '!*/appveyor.yml',
+    '!*/.appveyor.yml',
+    '!*/azure-pipelines.yml',
+    '!*/.azure-pipelines.yml',
+    '!*/.cirrus.star',
+    '!*/.cirrus.yml',
+    '!*/codecov.yml',
+    '!*/.codecov.yml',
+    '!*/.DS_Store',
+    '!*/.gitignore',
+    '!*/.gitpod.yml',
+    '!*/.hadolint.yaml',
+    '!*/.readthedocs.yaml',
+    '!*/.travis.yml',
+    '!*/vsts-ci.yml',
+    '!*/.vsts-ci.yml'
 ]

--- a/docs/check-reference.rst
+++ b/docs/check-reference.rst
@@ -61,6 +61,14 @@ The package distribution is larger (uncompressed) than the allowed size.
 
 Change that limit using configuration option ``max-distro-size-uncompressed``.
 
+expected-files
+**************
+
+The package distribution does not contain a file or directory that it was expected to contain.
+
+This can be used to test that changes to ``MANIFEST.in``, ``package_data``, and similar don't
+accidentally result in the exclusion of any expected files.
+
 files-only-differ-by-case
 *************************
 

--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -252,7 +252,7 @@ class _ExpectedFilesCheck(_CheckProtocol):
                     found_any = True
                     break
             if not found_any:
-                msg = f"[{self.check_name}] Did not find any files matching pattern '{pattern}'."
+                msg = f"[{self.check_name}] Did not find any directories matching pattern '{pattern}'."
                 out.append(msg)
         return out
 

--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -21,6 +21,7 @@ ALL_CHECKS = {
     "compiled-objects-have-debug-symbols",
     "distro-too-large-compressed",
     "distro-too-large-uncompressed",
+    "expected-files",
     "too-many-files",
     "files-only-differ-by-case",
     "mixed-file-extensions",
@@ -240,7 +241,7 @@ class _ExpectedFilesCheck(_CheckProtocol):
                 msg = f"[{self.check_name}] Did not find any files matching pattern '{pattern}'."
                 out.append(msg)
 
-        for pattern in self.unexpected_directory_patterns:
+        for pattern in self.directory_patterns:
             found_any = False
             for directory_path in distro_summary.directory_paths:
                 # NOTE: some archive formats have a trailing "/" on directory names,

--- a/src/pydistcheck/checks.py
+++ b/src/pydistcheck/checks.py
@@ -214,27 +214,71 @@ class _SpacesInPathCheck(_CheckProtocol):
         return out
 
 
+class _ExpectedFilesCheck(_CheckProtocol):
+    check_name = "expected-files"
+
+    def __init__(
+        self,
+        directory_patterns: List[str],
+        file_patterns: List[str],
+    ):
+        self.directory_patterns = [
+            d for d in directory_patterns if not d.startswith("!")
+        ]
+        self.file_patterns = [f for f in file_patterns if not f.startswith("!")]
+
+    def __call__(self, distro_summary: _DistributionSummary) -> List[str]:
+        out: List[str] = []
+        for pattern in self.file_patterns:
+            found_any = False
+            for file_path in distro_summary.file_paths:
+                if fnmatchcase(file_path, pattern):
+                    found_any = True
+                    break
+
+            if not found_any:
+                msg = f"[{self.check_name}] Did not find any files matching pattern '{pattern}'."
+                out.append(msg)
+
+        for pattern in self.unexpected_directory_patterns:
+            found_any = False
+            for directory_path in distro_summary.directory_paths:
+                # NOTE: some archive formats have a trailing "/" on directory names,
+                #       some do not
+                if fnmatchcase(directory_path, pattern) or fnmatchcase(
+                    directory_path, pattern + "/"
+                ):
+                    found_any = True
+                    break
+            if not found_any:
+                msg = f"[{self.check_name}] Did not find any files matching pattern '{pattern}'."
+                out.append(msg)
+        return out
+
+
 class _UnexpectedFilesCheck(_CheckProtocol):
     check_name = "unexpected-files"
 
     def __init__(
         self,
-        unexpected_directory_patterns: List[str],
-        unexpected_file_patterns: List[str],
+        directory_patterns: List[str],
+        file_patterns: List[str],
     ):
-        self.unexpected_directory_patterns = unexpected_directory_patterns
-        self.unexpected_file_patterns = unexpected_file_patterns
+        self.directory_patterns = [
+            d[1:] for d in directory_patterns if d.startswith("!")
+        ]
+        self.file_patterns = [f[1:] for f in file_patterns if f.startswith("!")]
 
     def __call__(self, distro_summary: _DistributionSummary) -> List[str]:
         out: List[str] = []
         for file_path in distro_summary.file_paths:
-            for pattern in self.unexpected_file_patterns:
+            for pattern in self.file_patterns:
                 if fnmatchcase(file_path, pattern):
                     msg = f"[{self.check_name}] Found unexpected file '{file_path}'."
                     out.append(msg)
 
         for directory_path in distro_summary.directory_paths:
-            for pattern in self.unexpected_directory_patterns:
+            for pattern in self.directory_patterns:
                 # NOTE: some archive formats have a trailing "/" on directory names,
                 #       some do not
                 if fnmatchcase(directory_path, pattern) or fnmatchcase(

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -20,7 +20,7 @@ from .checks import (
     _MixedFileExtensionCheck,
     _NonAsciiCharacterCheck,
     _SpacesInPathCheck,
-    _UnExpectedFilesCheck,
+    _UnexpectedFilesCheck,
 )
 from .config import _Config
 from .distribution_summary import _DistributionSummary
@@ -109,7 +109,7 @@ class ExitCodes:
 )
 @click.option(  # type: ignore[misc]
     "--expected-directories",
-    default=_Config.unexpected_directory_patterns,
+    default=_Config.expected_directories,
     show_default=True,
     type=str,
     help=(
@@ -121,8 +121,8 @@ class ExitCodes:
     ),
 )
 @click.option(  # type: ignore[misc]
-    "--unexpected-files",
-    default=_Config.unexpected_file_patterns,
+    "--expected-files",
+    default=_Config.expected_files,
     show_default=True,
     type=str,
     help=(

--- a/src/pydistcheck/config.py
+++ b/src/pydistcheck/config.py
@@ -21,41 +21,41 @@ _ALLOWED_CONFIG_VALUES = {
     "max_allowed_files",
     "max_allowed_size_compressed",
     "max_allowed_size_uncompressed",
-    "unexpected_directory_patterns",
-    "unexpected_file_patterns",
+    "expected_directories",
+    "expected_files",
 }
 
-_UNEXPECTED_DIRECTORIES = ",".join(
+_EXPECTED_DIRECTORIES = ",".join(
     [
-        "*/.appveyor",
-        "*/.binder",
-        "*/.circleci",
-        "*/.git",
-        "*/.github",
-        "*/.idea",
-        "*/.pytest_cache",
-        "*/.mypy_cache",
+        "!*/.appveyor",
+        "!*/.binder",
+        "!*/.circleci",
+        "!*/.git",
+        "!*/.github",
+        "!*/.idea",
+        "!*/.pytest_cache",
+        "!*/.mypy_cache",
     ]
 )
 
-_UNEXPECTED_FILES = ",".join(
+_EXPECTED_FILES = ",".join(
     [
-        "*/appveyor.yml",
-        "*/.appveyor.yml",
-        "*/azure-pipelines.yml",
-        "*/.azure-pipelines.yml",
-        "*/.cirrus.star",
-        "*/.cirrus.yml",
-        "*/codecov.yml",
-        "*/.codecov.yml",
-        "*/.DS_Store",
-        "*/.gitignore",
-        "*/.gitpod.yml",
-        "*/.hadolint.yaml",
-        "*/.readthedocs.yaml",
-        "*/.travis.yml",
-        "*/vsts-ci.yml",
-        "*/.vsts-ci.yml",
+        "!*/appveyor.yml",
+        "!*/.appveyor.yml",
+        "!*/azure-pipelines.yml",
+        "!*/.azure-pipelines.yml",
+        "!*/.cirrus.star",
+        "!*/.cirrus.yml",
+        "!*/codecov.yml",
+        "!*/.codecov.yml",
+        "!*/.DS_Store",
+        "!*/.gitignore",
+        "!*/.gitpod.yml",
+        "!*/.hadolint.yaml",
+        "!*/.readthedocs.yaml",
+        "!*/.travis.yml",
+        "!*/vsts-ci.yml",
+        "!*/.vsts-ci.yml",
     ]
 )
 
@@ -67,8 +67,8 @@ class _Config:
     max_allowed_files: int = 2000
     max_allowed_size_compressed: str = "50M"
     max_allowed_size_uncompressed: str = "75M"
-    unexpected_directory_patterns: str = _UNEXPECTED_DIRECTORIES
-    unexpected_file_patterns: str = _UNEXPECTED_FILES
+    expected_directories: str = _EXPECTED_DIRECTORIES
+    expected_files: str = _EXPECTED_FILES
 
     def __setattr__(self, name: str, value: Any) -> None:
         attr_name = name.replace("-", "_")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -639,8 +639,8 @@ def test_expected_files_does_not_raise_check_failure_if_all_patterns_match(distr
     result = runner.invoke(
         check,
         [
-            # wheel: lib/lib_baseball_metrics
-            # conda: lib/python3.9/site-packages/lib/lib_baseballmetrics.dylib
+            # (wheel) lib/lib_baseball_metrics
+            # (conda) lib/python3.9/site-packages/lib/lib_baseballmetrics.dylib
             "--expected-files=*/lib_baseballmetrics.*",
             os.path.join(TEST_DATA_DIR, distro_file),
         ],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,8 +64,8 @@ def test_update_from_dict_works_when_changing_all_values(base_config):
         "max_allowed_files": 8,
         "max_allowed_size_compressed": "2G",
         "max_allowed_size_uncompressed": "141K",
-        "unexpected_directory_patterns": "*/tests",
-        "unexpected_file_patterns": "*.xlsx,data/*.csv",
+        "expected_directories": "!*/tests",
+        "expected_files": "!*.xlsx,!data/*.csv",
     }
     assert (
         set(patch_dict.keys()) == _ALLOWED_CONFIG_VALUES
@@ -75,8 +75,8 @@ def test_update_from_dict_works_when_changing_all_values(base_config):
     assert base_config.max_allowed_files == 8
     assert base_config.max_allowed_size_compressed == "2G"
     assert base_config.max_allowed_size_uncompressed == "141K"
-    assert base_config.unexpected_directory_patterns == "*/tests"
-    assert base_config.unexpected_file_patterns == "*.xlsx,data/*.csv"
+    assert base_config.expected_directories == "!*/tests"
+    assert base_config.expected_files == "!*.xlsx,!data/*.csv"
 
 
 def test_update_from_toml_silently_returns_self_if_file_does_not_exist(base_config):
@@ -131,8 +131,8 @@ def test_update_from_toml_works_with_all_config_values(
         "max_allowed_files": 8,
         "max_allowed_size_compressed": "'3G'",
         "max_allowed_size_uncompressed": "'4.12G'",
-        "unexpected_directory_patterns": "[\n'tests/*'\n]",
-        "unexpected_file_patterns": "[\n'*.pq',\n'*/tests/data/*.csv']",
+        "expected_directories": "[\n'!tests/*'\n]",
+        "expected_files": "[\n'!*.pq',\n'!*/tests/data/*.csv']",
     }
     assert (
         set(patch_dict.keys()) == _ALLOWED_CONFIG_VALUES
@@ -150,8 +150,8 @@ def test_update_from_toml_works_with_all_config_values(
     assert base_config.max_allowed_files == 8
     assert base_config.max_allowed_size_compressed == "3G"
     assert base_config.max_allowed_size_uncompressed == "4.12G"
-    assert base_config.unexpected_directory_patterns == "tests/*"
-    assert base_config.unexpected_file_patterns == "*.pq,*/tests/data/*.csv"
+    assert base_config.expected_directories == "!tests/*"
+    assert base_config.expected_files == "!*.pq,!*/tests/data/*.csv"
 
 
 def test_update_from_toml_converts_lists_to_comma_delimited_string(base_config, tmpdir):


### PR DESCRIPTION
Fixes #233.

Adds a new check, `[expected-files]`, which allows the use of `pydistcheck` to assert that a distribution contains certain files or directories.

For example:

```toml
[tool.pydistcheck]
expected_files = [
    # at least one Python source file
    "*.py",
    # 0 static libraries
    "!.a",
    # exactly this specific Jinja2 template
    "coolpkg/resources/templates/the-template.j2"
]
```

## Notes for Reviewers

Calling this `breaking` because it changes some parameters:

* `--unexpected-directory-patterns` to `--expected-directories`
* `--unexpected-file-patterns` to `--expected-files`