### PR TITLE
[docs] expand docs on testing a Python distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,19 @@ For more background on the value of such a tool, see the SciPy 2022 talk "Does t
 
 ## Installation
 
-Install with `pipx`.
+Install with `pip`.
 
 ```shell
-pipx install pydistcheck
+pip install pydistcheck
 ```
+
+Or `conda`.
+
+```shell
+conda install -c conda-forge pydistcheck
+```
+
+For more details, see "Installation" ([link](./docs/installation.rst)).
 
 ## Quickstart
 

--- a/docs/check-reference.rst
+++ b/docs/check-reference.rst
@@ -172,6 +172,7 @@ Other relevant discussions:
 * `"Command prompt (Cmd. exe) command-line string limitation" (Windows docs, 2023) <https://learn.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/command-line-string-limitation>`__
 * `conda-build discussion about 255-character prefix limit (conda/conda-build#1482) <https://github.com/conda/conda-build/issues/1482#issuecomment-256530225>`__
 * `discussion about paths lengths (Python Discourse, 2023) <https://discuss.python.org/t/you-can-now-download-pypi-locally/32662/8>`__
+* `"check for long filepaths" (pre-commit/pre-commit feature request, 2022) <https://github.com/pre-commit/pre-commit-hooks/issues/760>`__
 
 too-many-files
 **************

--- a/docs/how-to-test-a-python-distribution.rst
+++ b/docs/how-to-test-a-python-distribution.rst
@@ -100,8 +100,6 @@ portability-related issues before they even make it into distributions.
           args: ['--maxkb=512']
         # files whose names only differ by case
         - id: check-case-conflict
-        # filepaths that won't be legal on Windows
-        - id: check-illegal-windows-names
         # symlinks that don't point to anything
         - id: check-symlinks
         # symlinks changed to regular files with content of a path

--- a/docs/how-to-test-a-python-distribution.rst
+++ b/docs/how-to-test-a-python-distribution.rst
@@ -117,6 +117,10 @@ portability-related issues before they even make it into distributions.
         # portability (and other) issues in shell scripts
         - id: shellcheck
 
+If you use GitHub Actions for continuous integration, consider adding a step
+with the ``hynek/build-and-inspect-python-package`` action (https://github.com/hynek/build-and-inspect-python-package)
+running prior to publishing packages.
+
 List of Tools
 *************
 

--- a/docs/how-to-test-a-python-distribution.rst
+++ b/docs/how-to-test-a-python-distribution.rst
@@ -122,8 +122,6 @@ List of Tools
 
 The following open-source tools can be used to detect (and in some cases repair) a wide range of Python packaging issues.
 
-Tools that accept distributions (sdists, wheels, ``.tar.gz``, ``.zip``, etc.) as inputs.
-
 * ``abi3audit`` (`link <https://github.com/trailofbits/abi3audit>`__) = detect ABI incompatibilities in wheels with CPython extensions
 * ``auditwheel`` (`link <https://github.com/pypa/auditwheel>`__) = detect and repair issues in Linux wheels that link to external shared libraries
 * ``auditwheel-emscripten`` (`link <https://github.com/ryanking13/auditwheel-emscripten>`__) = like ``auditwheel``, but focused on Python-in-a-web-browser applications (e.g. `pyodide auditwheel`_)
@@ -139,13 +137,5 @@ Tools that accept distributions (sdists, wheels, ``.tar.gz``, ``.zip``, etc.) as
 * ``repairwheel`` (`link <https://github.com/jvolkman/repairwheel>`__) = repair issues in Linux, macOS, and Windows wheels (wraps ``auditwheel``, ``delocate``, and ``delvewheel``)
 * ``twine`` (`link <https://github.com/pypa/twine>`__) = detect issues in package metadata (via ``twine check``)
 * ``wheel-inspect`` (`link <https://github.com/jwodder/wheel-inspect>`__) = dump summary information about wheels into machine-readable formats
-
-Tools that run on source code.
-
-* ``pre-commit-hooks`` (`link <https://github.com/pre-commit/pre-commit-hooks>`__) = some notable portability-focused hooks for the ``pre-commit`` tool
-    - ``check-added-large-files`` = detect large files added to source control (which might make it into distributions)
-    - ``check-case-conflict``
-    - 
-
 
 .. _pyodide auditwheel: https://pyodide.org/en/stable/usage/api/pyodide-cli.html

--- a/docs/how-to-test-a-python-distribution.rst
+++ b/docs/how-to-test-a-python-distribution.rst
@@ -25,10 +25,11 @@ So finally, FINALLY, it's time to package it up into a tarball and upload it to 
 Hopefully! But let's check.
 
 * `Are those distributions valid zip or tar files?`
-* `Will their READMEs look pretty when rendered on the PyPI homepage?`
-* `Do they have correctly-formatted platform tags?`
+* `Are they small enough to fit on PyPI?`
 * `Are they as small as possible, to be kind to package repositories and users with weak internet connections?`
 * `Are they free from filepaths and file names that some operating systems will struggle with?`
+* `Do they have correctly-formatted platform tags?`
+* `Will their READMEs look pretty when rendered on the PyPI homepage?`
 
 You checked those things, right? And in continuous integration, with open-source tools, not with manual steps and random ``tar`` incantations copied from Stack Overflow?
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,30 +3,28 @@ pydistcheck
 
 ``pydistcheck`` is a command-line interface (CLI) used to perform the following activities on Python package distributions.
 
+**enforce constraints in continuous integration**
+
+- *package contains all the expected files*
+- *package is free from any unexpected files*
+- *maximum package size (compressed and uncompressed)*
+- *filepaths portable to different operating systems*
+- *binary objects do not contain debugging symbols*
+
 **inspect the distribution's contents during development**
 
 - *how large is the package, compressed and uncompressed?*
 - *how many files does it contain?*
 - *what % of the package is Python files? compiled objects?*
-- *what's the difference between the compressed and uncompressed size?*
-
-**enforce constraints in continuous integration**
-
-- *should not be larger than* ``n`` *MB uncompressed*
-- *should not contain more than* ``x`` *files*
-- *should not contain non-portable filepaths*
-- *should not contain compiled code with debugging symbols*
+- *what are the largest files in the package?*
 
 .. code-block:: shell
 
     # install
-    pipx install pydistcheck
-
-    # run checks
-    pydistcheck dist/*
+    pip install pydistcheck
 
     # run checks and view diagnostic information
-    pydistcheck --inspect dist/*
+    pipx run pydistcheck --inspect dist/*
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Expands docs on how to test a Python distribution.

Adds link to https://github.com/pre-commit/pre-commit-hooks/issues/760 (which leads to https://github.com/pre-commit/pre-commit-hooks/issues/1007 and https://github.com/ShellMagick/commit-hooks/issues/1) to the `path-too-long` check.