### PR TITLE
[docs] fix formatting of blockquotes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.4
+    rev: v0.4.5
     hooks:
       # Run the linter.
       - id: ruff

--- a/docs/check-reference.rst
+++ b/docs/check-reference.rst
@@ -149,14 +149,14 @@ See below for details.
     *This meant that paths longer than this would not resolve and errors would result.*
     *In the latest versions of Windows, this limitation can be expanded to approximately 32,000 characters.*
     *Your administrator will need to activate the ``"Enable Win32 long paths"`` group policy, or set ``LongPathsEnabled`` to 1 in the registry key ``HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem``.*
-    
+
     *This allows the open() function, the os module and most other path functionality to accept and return paths longer than 260 characters.*
 
 `"Removing the Max Path Limitation" (Python Windows docs) <https://docs.python.org/3/using/windows.html#removing-the-max-path-limitation>`__
 
     *Git has a limit of 4096 characters for a filename, except on Windows when Git is compiled with msys.*
     *It uses an older version of the Windows API and there's a limit of 260 characters for a filename.*
-    
+
     *You can circumvent this by using another Git client on Windows or set ``core.longpaths`` to ``true``...*
 
 `Filename too long in Git for Windows (Stack Overflow answer) <https://stackoverflow.com/a/22575737/3986677>`__

--- a/docs/check-reference.rst
+++ b/docs/check-reference.rst
@@ -139,27 +139,27 @@ See below for details.
 
 `R CMD check source code <https://github.com/wch/r-source/blob/29559f9bf4df2c55ef5eace203cbe335bbd03f2f/src/library/tools/R/check.R#L839>`__:
 
-    *"Tarballs are only required to store paths of up to 100 bytes and cannot store those of more than 256 bytes"*.
+    "Tarballs are only required to store paths of up to 100 bytes and cannot store those of more than 256 bytes".
 
 `"Package Structure" (Writing R Extensions) <https://cran.r-project.org/doc/manuals/R-exts.html#Package-structure>`__:
 
-    *"...packages are normally distributed as tarballs, and these have a limit on path lengths: for maximal portability 100 bytes."*
+    "...packages are normally distributed as tarballs, and these have a limit on path lengths: for maximal portability 100 bytes."
 
 `"Removing the Max Path Limitation" (Python Windows docs) <https://docs.python.org/3/using/windows.html#removing-the-max-path-limitation>`__:
 
-    *"Windows historically has limited path lengths to 260 characters.*
-    *This meant that paths longer than this would not resolve and errors would result.*
-    *In the latest versions of Windows, this limitation can be expanded to approximately 32,000 characters.*
-    *Your administrator will need to activate the ``"Enable Win32 long paths"`` group policy, or set ``LongPathsEnabled`` to 1 in the registry key ``HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem``.*
+    "Windows historically has limited path lengths to 260 characters.
+    This meant that paths longer than this would not resolve and errors would result.
+    In the latest versions of Windows, this limitation can be expanded to approximately 32,000 characters.
+    Your administrator will need to activate the ``"Enable Win32 long paths"`` group policy, or set ``LongPathsEnabled`` to 1 in the registry key ``HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem``.
 
-    *This allows the open() function, the os module and most other path functionality to accept and return paths longer than 260 characters."*
+    This allows the ``open()`` function, the os module and most other path functionality to accept and return paths longer than 260 characters."
 
 `Filename too long in Git for Windows (Stack Overflow answer) <https://stackoverflow.com/a/22575737/3986677>`__:
 
-    *"Git has a limit of 4096 characters for a filename, except on Windows when Git is compiled with msys.*
-    *It uses an older version of the Windows API and there's a limit of 260 characters for a filename.*
+    "Git has a limit of 4096 characters for a filename, except on Windows when Git is compiled with msys.
+    It uses an older version of the Windows API and there's a limit of 260 characters for a filename.
 
-    *You can circumvent this by using another Git client on Windows or set ``core.longpaths`` to ``true``..."*
+    You can circumvent this by using another Git client on Windows or set ``core.longpaths`` to ``true``..."
 
 Other relevant discussions:
 

--- a/docs/check-reference.rst
+++ b/docs/check-reference.rst
@@ -137,28 +137,27 @@ This is primarily informed by the following limitations:
 
 See below for details.
 
-> *Tarballs are only required to store paths of up to 100 bytes and cannot store those of more than 256 bytes*.
+    *Tarballs are only required to store paths of up to 100 bytes and cannot store those of more than 256 bytes*.
 
 `R CMD check source code <https://github.com/wch/r-source/blob/29559f9bf4df2c55ef5eace203cbe335bbd03f2f/src/library/tools/R/check.R#L839>`__
 
-> *...packages are normally distributed as tarballs, and these have a limit on path lengths: for maximal portability 100 bytes.*
+    *...packages are normally distributed as tarballs, and these have a limit on path lengths: for maximal portability 100 bytes.*
 
 `"Package Structure" (Writing R Extensions) <https://cran.r-project.org/doc/manuals/R-exts.html#Package-structure>`__
 
-> *Windows historically has limited path lengths to 260 characters.*
-> *This meant that paths longer than this would not resolve and errors would result.*
->
-> *In the latest versions of Windows, this limitation can be expanded to approximately 32,000 characters.*
-> *Your administrator will need to activate the ``"Enable Win32 long paths"`` group policy, or set ``LongPathsEnabled`` to 1 in the registry key ``HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem``.*
->
-> *This allows the open() function, the os module and most other path functionality to accept and return paths longer than 260 characters.*
+    *Windows historically has limited path lengths to 260 characters.*
+    *This meant that paths longer than this would not resolve and errors would result.*
+    *In the latest versions of Windows, this limitation can be expanded to approximately 32,000 characters.*
+    *Your administrator will need to activate the ``"Enable Win32 long paths"`` group policy, or set ``LongPathsEnabled`` to 1 in the registry key ``HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem``.*
+    
+    *This allows the open() function, the os module and most other path functionality to accept and return paths longer than 260 characters.*
 
 `"Removing the Max Path Limitation" (Python Windows docs) <https://docs.python.org/3/using/windows.html#removing-the-max-path-limitation>`__
 
-> *Git has a limit of 4096 characters for a filename, except on Windows when Git is compiled with msys.*
-> *It uses an older version of the Windows API and there's a limit of 260 characters for a filename.*
->
-> *You can circumvent this by using another Git client on Windows or set ``core.longpaths`` to ``true``...*
+    *Git has a limit of 4096 characters for a filename, except on Windows when Git is compiled with msys.*
+    *It uses an older version of the Windows API and there's a limit of 260 characters for a filename.*
+    
+    *You can circumvent this by using another Git client on Windows or set ``core.longpaths`` to ``true``...*
 
 `Filename too long in Git for Windows (Stack Overflow answer) <https://stackoverflow.com/a/22575737/3986677>`__
 

--- a/docs/check-reference.rst
+++ b/docs/check-reference.rst
@@ -139,27 +139,27 @@ See below for details.
 
 `R CMD check source code <https://github.com/wch/r-source/blob/29559f9bf4df2c55ef5eace203cbe335bbd03f2f/src/library/tools/R/check.R#L839>`__:
 
-    "Tarballs are only required to store paths of up to 100 bytes and cannot store those of more than 256 bytes".
+    *"Tarballs are only required to store paths of up to 100 bytes and cannot store those of more than 256 bytes".*
 
 `"Package Structure" (Writing R Extensions) <https://cran.r-project.org/doc/manuals/R-exts.html#Package-structure>`__:
 
-    "...packages are normally distributed as tarballs, and these have a limit on path lengths: for maximal portability 100 bytes."
+    *"...packages are normally distributed as tarballs, and these have a limit on path lengths: for maximal portability 100 bytes."*
 
 `"Removing the Max Path Limitation" (Python Windows docs) <https://docs.python.org/3/using/windows.html#removing-the-max-path-limitation>`__:
 
-    "Windows historically has limited path lengths to 260 characters.
-    This meant that paths longer than this would not resolve and errors would result.
-    In the latest versions of Windows, this limitation can be expanded to approximately 32,000 characters.
-    Your administrator will need to activate the ``"Enable Win32 long paths"`` group policy, or set ``LongPathsEnabled`` to 1 in the registry key ``HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem``.
+    *"Windows historically has limited path lengths to 260 characters.*
+    *This meant that paths longer than this would not resolve and errors would result.*
+    *In the latest versions of Windows, this limitation can be expanded to approximately 32,000 characters.*
+    *Your administrator will need to activate the* ``"Enable Win32 long paths"`` *group policy, or set* ``LongPathsEnabled`` *to 1 in the registry key* ``HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem``.
 
-    This allows the ``open()`` function, the os module and most other path functionality to accept and return paths longer than 260 characters."
+    *This allows the* ``open()`` *function, the os module and most other path functionality to accept and return paths longer than 260 characters."*
 
 `Filename too long in Git for Windows (Stack Overflow answer) <https://stackoverflow.com/a/22575737/3986677>`__:
 
-    "Git has a limit of 4096 characters for a filename, except on Windows when Git is compiled with msys.
-    It uses an older version of the Windows API and there's a limit of 260 characters for a filename.
+    *"Git has a limit of 4096 characters for a filename, except on Windows when Git is compiled with msys.*
+    *It uses an older version of the Windows API and there's a limit of 260 characters for a filename.*
 
-    You can circumvent this by using another Git client on Windows or set ``core.longpaths`` to ``true``..."
+    *You can circumvent this by using another Git client on Windows or set* ``core.longpaths`` *to* ``true`` *..."*
 
 Other relevant discussions:
 

--- a/docs/check-reference.rst
+++ b/docs/check-reference.rst
@@ -137,29 +137,29 @@ This is primarily informed by the following limitations:
 
 See below for details.
 
-    *Tarballs are only required to store paths of up to 100 bytes and cannot store those of more than 256 bytes*.
+`R CMD check source code <https://github.com/wch/r-source/blob/29559f9bf4df2c55ef5eace203cbe335bbd03f2f/src/library/tools/R/check.R#L839>`__:
 
-`R CMD check source code <https://github.com/wch/r-source/blob/29559f9bf4df2c55ef5eace203cbe335bbd03f2f/src/library/tools/R/check.R#L839>`__
+    *"Tarballs are only required to store paths of up to 100 bytes and cannot store those of more than 256 bytes"*.
 
-    *...packages are normally distributed as tarballs, and these have a limit on path lengths: for maximal portability 100 bytes.*
+`"Package Structure" (Writing R Extensions) <https://cran.r-project.org/doc/manuals/R-exts.html#Package-structure>`__:
 
-`"Package Structure" (Writing R Extensions) <https://cran.r-project.org/doc/manuals/R-exts.html#Package-structure>`__
+    *"...packages are normally distributed as tarballs, and these have a limit on path lengths: for maximal portability 100 bytes."*
 
-    *Windows historically has limited path lengths to 260 characters.*
+`"Removing the Max Path Limitation" (Python Windows docs) <https://docs.python.org/3/using/windows.html#removing-the-max-path-limitation>`__:
+
+    *"Windows historically has limited path lengths to 260 characters.*
     *This meant that paths longer than this would not resolve and errors would result.*
     *In the latest versions of Windows, this limitation can be expanded to approximately 32,000 characters.*
     *Your administrator will need to activate the ``"Enable Win32 long paths"`` group policy, or set ``LongPathsEnabled`` to 1 in the registry key ``HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem``.*
 
-    *This allows the open() function, the os module and most other path functionality to accept and return paths longer than 260 characters.*
+    *This allows the open() function, the os module and most other path functionality to accept and return paths longer than 260 characters."*
 
-`"Removing the Max Path Limitation" (Python Windows docs) <https://docs.python.org/3/using/windows.html#removing-the-max-path-limitation>`__
+`Filename too long in Git for Windows (Stack Overflow answer) <https://stackoverflow.com/a/22575737/3986677>`__:
 
-    *Git has a limit of 4096 characters for a filename, except on Windows when Git is compiled with msys.*
+    *"Git has a limit of 4096 characters for a filename, except on Windows when Git is compiled with msys.*
     *It uses an older version of the Windows API and there's a limit of 260 characters for a filename.*
 
-    *You can circumvent this by using another Git client on Windows or set ``core.longpaths`` to ``true``...*
-
-`Filename too long in Git for Windows (Stack Overflow answer) <https://stackoverflow.com/a/22575737/3986677>`__
+    *You can circumvent this by using another Git client on Windows or set ``core.longpaths`` to ``true``..."*
 
 Other relevant discussions:
 

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -4,7 +4,7 @@ channels:
   - nodefaults
   - conda-forge
 dependencies:
-  - python=3.10
-  - sphinx
-  - "sphinx-click>=4.3.0"
-  - "sphinx_rtd_theme>=0.5"
+  - python =3.12
+  - sphinx >=7.3
+  - sphinx-click >=6.0
+  - sphinx_rtd_theme >=2.0


### PR DESCRIPTION
Fixes some formatting issues introduced in the docs added in #244

Before:

<img width="1133" alt="image" src="https://github.com/jameslamb/pydistcheck/assets/7608904/9df239bd-b275-44df-879e-23e7f8818b69">

After:

<img width="1107" alt="image" src="https://github.com/jameslamb/pydistcheck/assets/7608904/be914ffe-db1e-4f01-ad83-ed971b22f972">

Reference: https://restructuredtext.readthedocs.io/en/latest/rst_guide.html#blockquotes

While I'm in here, also:

* updates versions of dependencies for docs builds
* updates versions in `pre-commit` via `pre-commit autoupdate`

### How I tested this

Enabled builds on readthedocs.

build: https://readthedocs.org/projects/pydistcheck/builds/24477913/
docs: https://pydistcheck.readthedocs.io/en/docs-fix/check-reference.html#path-too-long