### PR TITLE
[ci] move shellcheck to pre-commit, use shellcheck-py

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,10 +24,8 @@ jobs:
           conda install \
             --yes \
             -c conda-forge \
-              'mypy>=0.931' \
               pre-commit \
               requests \
-              shellcheck \
               types-requests \
               yamllint
           sudo apt-get update

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,8 @@ repos:
       - id: ruff-format
         args: ["--config", "pyproject.toml"]
         types_or: [python, jupyter]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ["--exclude=SC2002"]

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,6 @@ lint:
 		-i 4 \
 		-sr \
 		./bin
-	shellcheck \
-		--exclude=SC2002 \
-		bin/*.sh
 	yamllint \
 		--strict \
 		-d '{extends: default, rules: {braces: {max-spaces-inside: 1}, truthy: {check-keys: false}, line-length: {max: 120}}}' \

--- a/bin/create-release-pr
+++ b/bin/create-release-pr
@@ -27,12 +27,12 @@ VERSION=$(
         tr -d ' "'
 )
 
-git checkout -b release/v${VERSION}
+git checkout -b "release/v${VERSION}"
 git add ./src/pydistcheck/__init__.py
 
 commit_msg="release v${VERSION}"
 git commit -m "${commit_msg}"
-git push origin release/v${VERSION}
+git push origin "release/v${VERSION}"
 
 gh pr create \
     --repo jameslamb/pydistcheck \


### PR DESCRIPTION
Moves `shellcheck` into `pre-commit` checks, and uses https://github.com/shellcheck-py/shellcheck-py so it can be installed automatically from PyPI (instead of needing to be installed separately before running linting).

This also uses `pre-commit`'s mechanism for detecting files, and doesn't rely on file extensions. So it caught a few other uncaught `shellcheck` things in other files 🙌🏻 