### PR TITLE
[ci] use shfmt-py in pre-commit to run shfmt

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -28,7 +28,4 @@ jobs:
               requests \
               types-requests \
               yamllint
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y \
-            shfmt
           make lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.5
+    rev: v0.4.6
     hooks:
       # Run the linter.
       - id: ruff
@@ -31,6 +31,11 @@ repos:
       - id: ruff-format
         args: ["--config", "pyproject.toml"]
         types_or: [python, jupyter]
+  - repo: https://github.com/maxwinterstein/shfmt-py
+    rev: v3.7.0.1
+    hooks:
+      - id: shfmt
+        args: ["--indent=4", "--space-redirects", "--write"]
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,6 @@ clean:
 	rm -rf ./tests/data/baseballmetrics/baseballmetrics.egg-info
 	rm -rf ./tests/data/baseballmetrics/_skbuild
 
-.PHONY: format
-format:
-	shfmt \
-		--write \
-		--indent 4 \
-		--space-redirects \
-		./bin
-
 .PHONY: install
 install:
 	pipx install --force '.[conda]'
@@ -43,11 +35,6 @@ install:
 .PHONY: lint
 lint:
 	pre-commit run --all-files
-	shfmt \
-		-d \
-		-i 4 \
-		-sr \
-		./bin
 	yamllint \
 		--strict \
 		-d '{extends: default, rules: {braces: {max-spaces-inside: 1}, truthy: {check-keys: false}, line-length: {max: 120}}}' \


### PR DESCRIPTION
Proposes using `shfmt-py` to run `shfmt` via `pre-commit`.

ref: https://github.com/MaxWinterstein/shfmt-py

That simplifies the configuration a bit and removes the need to do an `apt-get install` in the linting CI job.