### PR TITLE
[docs] add example with 'pip download'

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,18 @@ For more details, see "Installation" ([link](./docs/installation.rst)).
 
 ## Quickstart
 
-Try it out on the test data in this project ...
+Try it out on a package you like.
+
+```shell
+pip download \
+  --no-deps \
+  -d ./downloads \
+  pyarrow
+
+pydistcheck --inspect ./downloads/*.whl
+```
+
+Or on the test data in this repo ...
 
 ```shell
 pydistcheck tests/data/problematic-package-*

--- a/src/pydistcheck/__init__.py
+++ b/src/pydistcheck/__init__.py
@@ -1,4 +1,4 @@
 # no one should be importing from this package
 __all__ = []  # type: ignore[var-annotated]
 
-__version__ = "0.7.1"
+__version__ = "0.7.1.99"


### PR DESCRIPTION
Also bumps development version to `0.7.1.99`.