### PR TITLE
[ci] stop using mambaforge

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           environment-file: docs/env.yml
           activate-environment: pydistcheck-docs
-          channels: nodefaults,conda-forge
+          miniforge-version: latest
       - name: build docs
         shell: bash -l {0}
         run: |

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -22,8 +22,6 @@ jobs:
         with:
           environment-file: docs/env.yml
           activate-environment: pydistcheck-docs
-          miniforge-variant: Mambaforge
-          use-mamba: true
       - name: build docs
         shell: bash -l {0}
         run: |

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           environment-file: docs/env.yml
           activate-environment: pydistcheck-docs
+          channels: nodefaults,conda-forge
       - name: build docs
         shell: bash -l {0}
         run: |

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -45,8 +45,6 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install \
-            --override-channels \
-            --channel conda-forge \
             --yes \
               pipx \
               requests

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -33,8 +33,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: pydistcheck-tests
-          miniforge-variant: Mambaforge
-          use-mamba: true
           python-version: ${{ matrix.python_version }}
       - name: Install extra tools on Linux
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: pydistcheck-tests
-          channels: nodefaults,conda-forge
+          miniforge-version: latest
           python-version: ${{ matrix.python_version }}
       - name: Install extra tools on Linux
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: pydistcheck-tests
+          channels: nodefaults,conda-forge
           python-version: ${{ matrix.python_version }}
       - name: Install extra tools on Linux
         if: startsWith(matrix.os, 'ubuntu')
@@ -44,6 +45,8 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install \
+            --override-channels \
+            --channel conda-forge \
             --yes \
               pipx \
               requests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: pydistcheck-tests
-          channels: nodefaults,conda-forge
+          miniforge-version: latest
           python-version: ${{ matrix.python_version }}
       - name: Install extra tools on Linux
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -57,6 +57,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: pydistcheck-tests
+          channels: nodefaults,conda-forge
           python-version: ${{ matrix.python_version }}
       - name: Install extra tools on Linux
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -57,8 +57,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: pydistcheck-tests
-          miniforge-variant: Mambaforge
-          use-mamba: true
           python-version: ${{ matrix.python_version }}
       - name: Install extra tools on Linux
         if: startsWith(matrix.os, 'ubuntu')

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.5
+    rev: v0.6.8
     hooks:
       # Run the linter.
       - id: ruff

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -195,7 +195,11 @@ pydistcheck \
     ./smoke-tests/*.whl
 
 get-files pandas
-pydistcheck ./smoke-tests/*
+pydistcheck \
+    --max-allowed-files=2500 \
+    --max-allowed-size-compressed=70M \
+    --max-allowed-size-uncompressed=300M \
+    ./smoke-tests/*
 
 get-files Pillow
 pydistcheck \


### PR DESCRIPTION
The `conda-incubator/setup-miniconda` action is raising these warnings sometimes treated as errors:

> *Warning: Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience. More details at https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/.*
> *Warning: ERROR: executing pre_install.sh failed*

This fixes that by just switching to miniforge, per https://github.com/conda-incubator/setup-miniconda?tab=readme-ov-file#example-10-miniforge.

It also updates pre-commit hook versions with `pre-commit autoupdate`.