### PR TITLE
add --select option to make checks opt-in

### DIFF
--- a/docs/_static/defaults.toml
+++ b/docs/_static/defaults.toml
@@ -5,6 +5,12 @@
 # a complete list.
 ignore = []
 
+# List of checks to run.
+# If non-empty, then only these checks will run.
+# See https://pydistcheck.readthedocs.io/en/latest/check-reference.html for
+# a complete list.
+select = []
+
 # Set to true to print a summary of the distribution, like its total
 # size and largest files.
 inspect = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ profile = "black"
 
 [tool.mypy]
 exclude = 'docs/conf\.py$|build/*'
-explicit_package_bases = true
 ignore_missing_imports = true
 mypy_path = "./src:./tests/data"
 strict = true

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -193,6 +193,7 @@ def check(  # noqa: PLR0913
         "max_allowed_size_compressed": max_allowed_size_compressed,
         "max_allowed_size_uncompressed": max_allowed_size_uncompressed,
         "max_path_length": max_path_length,
+        "select": select,
         "expected_directories": expected_directories,
         "expected_files": expected_files,
     }
@@ -255,11 +256,11 @@ def check(  # noqa: PLR0913
         _NonAsciiCharacterCheck(),
     ]
 
-    # if 'select' is non-empty, use that value and ignore
+    # if 'select' is non-empty, use only the checks indicated by that option
     if selected_checks:
         checks = [c for c in checks if c.check_name in selected_checks]
+    # otherwise, run all checks except those indicated by 'ignore'
     elif checks_to_ignore:
-        # filter out ignored checks
         checks = [c for c in checks if c.check_name not in checks_to_ignore]
 
     any_errors_found = False

--- a/src/pydistcheck/config.py
+++ b/src/pydistcheck/config.py
@@ -24,6 +24,7 @@ _ALLOWED_CONFIG_VALUES = {
     "max_allowed_size_compressed",
     "max_allowed_size_uncompressed",
     "max_path_length",
+    "select",
 }
 
 _EXPECTED_DIRECTORIES = (
@@ -67,6 +68,7 @@ class _Config:
     max_allowed_size_compressed: str = "50M"
     max_allowed_size_uncompressed: str = "75M"
     max_path_length: int = 200
+    select: Sequence[str] = ()
 
     def __setattr__(self, name: str, value: Any) -> None:
         attr_name = name.replace("-", "_")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,6 +58,8 @@ def test_update_from_dict_works_when_changing_all_values(base_config):
     assert base_config.max_allowed_files == 7
     assert base_config.max_allowed_size_compressed == "1G"
     assert base_config.max_allowed_size_uncompressed == "18K"
+    # TODO: "ignore" should be a list
+    # TODO: "select" needs to be added
     patch_dict = {
         "expected_directories": "!*/tests",
         "expected_files": "!*.xlsx,!data/*.csv",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,6 +59,7 @@ def test_update_from_dict_works_when_changing_all_values(base_config):
     assert base_config.max_allowed_files == 7
     assert base_config.max_allowed_size_compressed == "1G"
     assert base_config.max_allowed_size_uncompressed == "18K"
+    assert base_config.select == ()
     # TODO: "ignore" should be a list
     # TODO: "select" needs to be added
     patch_dict = {
@@ -70,6 +71,7 @@ def test_update_from_dict_works_when_changing_all_values(base_config):
         "max_allowed_size_compressed": "2G",
         "max_allowed_size_uncompressed": "141K",
         "max_path_length": 600,
+        "select": ["distro-too-large-compressed"],
     }
     assert (
         set(patch_dict.keys()) == _ALLOWED_CONFIG_VALUES
@@ -83,6 +85,7 @@ def test_update_from_dict_works_when_changing_all_values(base_config):
     assert base_config.max_allowed_size_compressed == "2G"
     assert base_config.max_allowed_size_uncompressed == "141K"
     assert base_config.max_path_length == 600
+    assert base_config.select == ["distro-too-large-compressed"]
 
 
 def test_update_from_toml_silently_returns_self_if_file_does_not_exist(base_config):
@@ -140,6 +143,7 @@ def test_update_from_toml_works_with_all_config_values(
         "max_allowed_size_compressed": "'3G'",
         "max_allowed_size_uncompressed": "'4.12G'",
         "max_path_length": 25,
+        "select": "[\n'mixed-file-extensions',\n'path-contains-non-ascii-characters'\n]",
     }
     assert (
         set(patch_dict.keys()) == _ALLOWED_CONFIG_VALUES
@@ -160,3 +164,7 @@ def test_update_from_toml_works_with_all_config_values(
     assert base_config.max_allowed_size_compressed == "3G"
     assert base_config.max_allowed_size_uncompressed == "4.12G"
     assert base_config.max_path_length == 25
+    assert base_config.select == [
+        "mixed-file-extensions",
+        "path-contains-non-ascii-characters",
+    ]

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -14,7 +14,7 @@ DOCS_ROOT = Path(__file__).parents[1].joinpath("docs")
 
 def test_default_toml_config():
     # NOTE: this intentionally does not use pydistcheck._Config.update_from_toml(),
-    #       to ensure that's bugs in that class don't also cause this test to accidentally pass.
+    #       to ensure that bugs in that class don't also cause this test to accidentally pass.
     defaults_example_file = DOCS_ROOT.joinpath("_static/defaults.toml")
     with open(defaults_example_file, "rb") as f:
         config_dict = tomllib.load(f)
@@ -36,6 +36,7 @@ def test_default_toml_config():
     config.expected_directories = tuple(config.expected_directories)
     config.expected_files = tuple(config.expected_files)
     config.ignore = ()
+    config.select = ()
 
     assert (
         config == _Config()


### PR DESCRIPTION
fixes #264

Introduces a new configuration option, `--select`, with usage similar to `ruff`'s option of the same name. If this flag (or the corresponding `pyproject.toml` option) is supplied, it switches `pydistcheck` from opt-out behavior ("run all checks except those in `ignore`") to opt-in behavior ("run only the checks indicated by `select`").

For example, to say "only run the checks on file size" and avoid running any others:

```shell
pydistcheck \
  --select 'distro-too-large-compressed' \
  --max-distro-size-compressed '100M' \
  --select 'distro-too-large-uncompressed' \
  --max-distro-size-uncompressed '300M' \
  dist/*.whl
```