### PR TITLE
add Python 3.13 support, misc. CI improvements

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -23,8 +23,10 @@ jobs:
         include:
           - os: ubuntu-latest
             python_version: '3.8'
+          - os: ubuntu-latest
+            python_version: '3.13'
           - os: windows-latest
-            python_version: '3.10'
+            python_version: '3.12'
     steps:
       - name: check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -93,9 +93,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python_version: '3.9'
-          - os: ubuntu-latest
-            python_version: '3.12'
+            python_version: '3.10'
     steps:
       - name: check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,20 +31,22 @@ jobs:
             python_version: '3.11'
           - os: ubuntu-latest
             python_version: '3.12'
+          - os: ubuntu-latest
+            python_version: '3.13'
           #########
           # macOS #
           #########
           - os: macOS-13
             python_version: '3.8'
           - os: macOS-latest
-            python_version: '3.10'
+            python_version: '3.13'
           ###########
           # Windows #
           ###########
           - os: windows-latest
             python_version: '3.8'
           - os: windows-latest
-            python_version: '3.10'
+            python_version: '3.13'
     steps:
       - name: Prevent conversion of line endings on Windows
         if: startsWith(matrix.os, 'windows')
@@ -93,7 +95,7 @@ jobs:
           - os: ubuntu-latest
             python_version: '3.9'
           - os: ubuntu-latest
-            python_version: '3.10'
+            python_version: '3.12'
     steps:
       - name: check out repository
         uses: actions/checkout@v4
@@ -130,9 +132,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python_version: '3.11'
+            python_version: '3.12'
           - os: macOS-13
-            python_version: '3.10'
+            python_version: '3.11'
     steps:
       - name: check out repository
         uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,8 @@ repos:
         args: ["--config-file", "pyproject.toml"]
         exclude: "tests"
         additional_dependencies:
+          - click
+          - tomli
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-toml
       - id: end-of-file-fixer
@@ -13,7 +13,7 @@ repos:
         name: isort (python)
         args: ["--settings-path", "pyproject.toml"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.12.0
     hooks:
       - id: mypy
         args: ["--config-file", "pyproject.toml"]
@@ -22,7 +22,7 @@ repos:
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.8
+    rev: v0.7.0
     hooks:
       # Run the linter.
       - id: ruff

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -4,7 +4,7 @@ channels:
   - nodefaults
   - conda-forge
 dependencies:
-  - python =3.12
+  - python =3.13
   - sphinx >=7.3
   - sphinx-click >=6.0
   - sphinx_rtd_theme >=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,10 @@ ignore = [
     "E501",
     # (pylint) Magic value used in comparison, consider replacing with a constant
     "PLR2004",
+    # (flake8-pytest-style) scope='function' is implied in @pytest.fixture()
+    "PT003",
+    # (flake8-pytest-style) Wrong values type in @pytest.mark.parametrize expected list of tuple
+    "PT007",
     # (flake8-bandit) subprocess call: check for execution of untrusted input
     "S603",
     # (flake8-simplify) use ternary operator instead of if-else
@@ -115,8 +119,12 @@ select = [
     "PERF",
     # pygrep-hooks
     "PGH",
+    # flake8-pie
+    "PIE",
     # pylint
     "PL",
+    # flake8-pytest-style
+    "PT",
     # flake8-pyi
     "PYI",
     # flake8-return
@@ -149,6 +157,8 @@ select = [
 "tests/*" = [
     # (flake8-annotations)
     "ANN",
+    # (pydocstyle)
+    "D",
     # (flake8-bugbear) Found useless expression
     "B018",
     # (flake8-bandit) use of assert detected

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -35,20 +35,20 @@ class ExitCodes:
     UNSUPPORTED_FILE_TYPE = 2
 
 
-@click.command()  # type: ignore[misc]
-@click.argument(  # type: ignore[misc]
+@click.command()
+@click.argument(
     "filepaths",
     type=click.Path(exists=True),
     nargs=-1,
 )
-@click.option(  # type: ignore[misc]
+@click.option(
     "--version",
     is_flag=True,
     show_default=False,
     default=False,
     help="Print the version of pydistcheck and exit.",
 )
-@click.option(  # type: ignore[misc]
+@click.option(
     "--config",
     type=click.Path(exists=True),
     default=None,
@@ -57,7 +57,7 @@ class ExitCodes:
         "If provided, pyproject.toml will be ignored."
     ),
 )
-@click.option(  # type: ignore[misc]
+@click.option(
     "--ignore",
     multiple=True,
     default=_Config.ignore,
@@ -67,7 +67,7 @@ class ExitCodes:
         "complete list of valid options. Can be passed multiple times."
     ),
 )
-@click.option(  # type: ignore[misc]
+@click.option(
     "--inspect",
     is_flag=True,
     show_default=False,
@@ -76,7 +76,7 @@ class ExitCodes:
         "Print a summary of the distribution, like its total size and largest files."
     ),
 )
-@click.option(  # type: ignore[misc]
+@click.option(
     "--expected-directories",
     multiple=True,
     default=_Config.expected_directories,
@@ -89,7 +89,7 @@ class ExitCodes:
         "Can be passed multiple times."
     ),
 )
-@click.option(  # type: ignore[misc]
+@click.option(
     "--expected-files",
     multiple=True,
     default=_Config.expected_files,
@@ -102,14 +102,14 @@ class ExitCodes:
         "Can be passed multiple times."
     ),
 )
-@click.option(  # type: ignore[misc]
+@click.option(
     "--max-allowed-files",
     default=_Config.max_allowed_files,
     show_default=True,
     type=int,
     help="maximum number of files allowed in the distribution",
 )
-@click.option(  # type: ignore[misc]
+@click.option(
     "--max-allowed-size-compressed",
     default=_Config.max_allowed_size_compressed,
     show_default=True,
@@ -123,7 +123,7 @@ class ExitCodes:
         "  - G = gigabytes"
     ),
 )
-@click.option(  # type: ignore[misc]
+@click.option(
     "--max-allowed-size-uncompressed",
     default=_Config.max_allowed_size_uncompressed,
     show_default=True,
@@ -137,7 +137,7 @@ class ExitCodes:
         "  - G = gigabytes"
     ),
 )
-@click.option(  # type: ignore[misc]
+@click.option(
     "--max-path-length",
     default=_Config.max_path_length,
     show_default=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -796,7 +796,7 @@ def test_debug_symbols_check_works(distro_file):
     if "macosx" in distro_file:
         # macOS wheels
         lib_file = r"\"lib/lib_baseballmetrics\.dylib\"'"
-        if platform.startswith("cygwin") or platform.startswith("win"):
+        if platform.startswith(("cygwin", "win")):
             debug_cmd = r"'llvm\-nm \-a " + lib_file
         else:
             # dsymutil works on both macOS and Linux
@@ -804,7 +804,7 @@ def test_debug_symbols_check_works(distro_file):
     elif "osx-64" in distro_file:
         # macOS conda packages
         lib_file = r"\"lib/python3\.9/site-packages/lib/lib_baseballmetrics\.dylib\"'\."
-        if platform.startswith("cygwin") or platform.startswith("win"):
+        if platform.startswith(("cygwin", "win")):
             debug_cmd = r"'llvm\-nm \-a " + lib_file
         else:
             # dsymutil works on both macOS and Linux

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,7 +44,7 @@ def test_file_size_from_number_switches_unit_str_based_on_size():
 
 
 @pytest.mark.parametrize(
-    "file_size,expected_str",
+    ("file_size", "expected_str"),
     [
         (_FileSize.from_number(110), "0.1K"),
         (_FileSize.from_number(150), "0.1K"),


### PR DESCRIPTION
* adds Python 3.13 support
* adds all runtime dependencies to `pre-commit` env for `mypy`, so it can run more thorough checks
* updates all `pre-commit` hooks with `pre-commit autoupdate`

Fixes the following new `ruff` errors:

```text
tests/test_config.py:11:17: PT003 `scope='function'` is implied in `@pytest.fixture()`
tests/test_cli.py:114:35: PT007 Wrong values type in `@pytest.mark.parametrize` expected `list` of `tuple`
tests/test_cli.py:799:12: PIE810 Call `startswith` once with a `tuple`
tests/test_utils.py:47:5: PT006 Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
```