### PR TITLE
[ci] check docs with 'rstcheck'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,3 +43,12 @@ repos:
     hooks:
       - id: shellcheck
         args: ["--exclude=SC2002"]
+  - repo: https://github.com/rstcheck/rstcheck
+    rev: v6.2.4
+    hooks:
+    - id: rstcheck
+      args: ["--config=pyproject.toml"]
+      additional_dependencies:
+        - click
+        - sphinx>=7.3
+        - sphinx-click>=6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,9 +46,9 @@ repos:
   - repo: https://github.com/rstcheck/rstcheck
     rev: v6.2.4
     hooks:
-    - id: rstcheck
-      args: ["--config=pyproject.toml"]
-      additional_dependencies:
-        - click
-        - sphinx>=7.3
-        - sphinx-click>=6.0
+      - id: rstcheck
+        args: ["--config=pyproject.toml"]
+        additional_dependencies:
+          - click
+          - sphinx>=7.3
+          - sphinx-click>=6.0

--- a/docs/check-reference.rst
+++ b/docs/check-reference.rst
@@ -118,6 +118,7 @@ Some programs may use file extensions, instead of more reliable mechanisms like 
 .. code-block:: python
 
     if filepath.endswith(".yaml"):
+        x = yaml.safe_load(filepath)
 
 In such cases, having a mix of file extensions can lead to only a subset of relevant files being matched.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -6,8 +6,8 @@ This page describes how to configure ``pydistcheck``.
 ``pydistcheck`` combines different sources of configuration in the following order.
 
 1. default values
-2. :ref:`pyproject-toml` (or custom TOML file passed via ``--config``)
-3. :ref:`cli-arguments`
+2. `pyproject-toml`_ (or custom TOML file passed via ``--config``)
+3. `cli-arguments`_
 
 Configuration found further down the list overrides configuration found earlier in the list.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,12 @@ ignore_missing_imports = true
 mypy_path = "./src:./tests/data"
 strict = true
 
+[tool.rstcheck]
+ignore_directives = [
+    # rstcheck does not understand directives from extension 'sphinx-click'
+    "click"
+]
+
 [tool.ruff]
 line-length = 88
 # this should be set to the oldest version of python the project supports


### PR DESCRIPTION
Adds linting on the docs with `rstcheck` (https://github.com/rstcheck/rstcheck).

This caught a few small issues 🎉 

```text
docs/check-reference.rst:120: (ERROR/3) (python) expected an indented block after 'if' statement on line 1
docs/configuration.rst:23: (INFO/1) No directive entry for "click" in module "docutils.parsers.rst.languages.en".
docs/configuration.rst:23: (ERROR/3) Unknown directive type "click".
docs/configuration.rst:18: (INFO/1) Hyperlink target "cli-arguments" is not referenced.
docs/configuration.rst:27: (INFO/1) Hyperlink target "pyproject-toml" is not referenced.
Error! Issues detected.
```