### PR TITLE
[ci] skip TYPE_CHECKING blocks in code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,6 @@ test-data-conda-dot-conda-packages:
 test:
 	pytest \
 		--cov pydistcheck \
-		--cov-fail-under=98 \
 		./tests
 
 .PHONY: test-local
@@ -99,7 +98,6 @@ test-local:
 	PYTHONPATH=src \
 	pytest \
 		--cov=src/pydistcheck \
-		--cov-fail-under=98 \
 		--cov-report="term" \
 		--cov-report="html:htmlcov" \
 		./tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,13 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.coverage.report]
+fail_under = 98.00
+exclude_also = [
+    # skip type-checking blocks when calculating code coverage
+    "if TYPE_CHECKING:"
+]
+
 [tool.isort]
 line_length = 88
 profile = "black"


### PR DESCRIPTION
`if TYPE_CHECKING` blocks contain code/imports that are only executed when using a type checker like `pyright` or `mypy`... not code that executes during normal usage of this tool.

This proposes excluding blocks like that from code coverage calculations, to focus development on covering the codepaths that are accessed during normal usage.