### PR TITLE
Support more units and ignore case in file-size config options

### DIFF
--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -126,7 +126,7 @@ class ExitCodes:
     show_default=True,
     type=str,
     help=(
-        "maximum allowed compressed size, a string like '1.5M' indicating"
+        "maximum allowed compressed size, a string like '1.5MB' indicating"
         " '1.5 megabytes'. Supported units:\n"
         "  - B = bytes\n"
         "  - KB = kilobytes\n"
@@ -143,12 +143,15 @@ class ExitCodes:
     show_default=True,
     type=str,
     help=(
-        "maximum allowed uncompressed size, a string like '1.5M' indicating"
+        "maximum allowed uncompressed size, a string like '1.5MB' indicating"
         " '1.5 megabytes'. Supported units:\n"
         "  - B = bytes\n"
-        "  - K = kilobytes\n"
-        "  - M = megabytes\n"
-        "  - G = gigabytes"
+        "  - KB = kilobytes\n"
+        "  - K, Ki = kibibytes\n"
+        "  - MB = megabytes\n"
+        "  - M, Mi = mebibytes\n"
+        "  - GB = gigabytes\n"
+        "  - G, Gi = gibibytes"
     ),
 )
 @click.option(

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -129,9 +129,12 @@ class ExitCodes:
         "maximum allowed compressed size, a string like '1.5M' indicating"
         " '1.5 megabytes'. Supported units:\n"
         "  - B = bytes\n"
-        "  - K = kilobytes\n"
-        "  - M = megabytes\n"
-        "  - G = gigabytes"
+        "  - KB = kilobytes\n"
+        "  - K, Ki = kibibytes\n"
+        "  - MB = megabytes\n"
+        "  - M, Mi = mebibytes\n"
+        "  - GB = gigabytes\n"
+        "  - G, Gi = gibibytes"
     ),
 )
 @click.option(

--- a/src/pydistcheck/utils.py
+++ b/src/pydistcheck/utils.py
@@ -5,7 +5,18 @@ not specific to package distributions
 
 from typing import Tuple
 
-_UNIT_TO_NUM_BYTES = {"B": 1, "K": 1024, "M": 1024**2, "G": 1024**3}
+_UNIT_TO_NUM_BYTES = {
+    "b": 1,
+    "k": 1024,
+    "kb": 1000,
+    "ki": 1024,
+    "m": 1024**2,
+    "mb": 1000000,
+    "mi": 1024**2,
+    "g": 1024**3,
+    "gb": 1000000000,
+    "gi": 1024**3,
+}
 
 
 def _recommend_size_str(num_bytes: int) -> Tuple[float, str]:
@@ -35,7 +46,7 @@ class _FileSize:
 
     @property
     def total_size_bytes(self) -> int:
-        return int(self._num * _UNIT_TO_NUM_BYTES[self._unit_str])
+        return int(self._num * _UNIT_TO_NUM_BYTES[self._unit_str.lower()])
 
     def __eq__(self, other: object) -> bool:
         return (

--- a/src/pydistcheck/utils.py
+++ b/src/pydistcheck/utils.py
@@ -5,6 +5,11 @@ not specific to package distributions
 
 from typing import Tuple
 
+# references:
+#
+#   * https://physics.nist.gov/cuu/Units/binary.html
+#   * https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
+#
 _UNIT_TO_NUM_BYTES = {
     "b": 1,
     "k": 1024,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,9 +3,33 @@ import pytest
 from pydistcheck.utils import _FileSize
 
 
-def test_file_size_minimally_works():
-    fs = _FileSize(num=1.0, unit_str="G")
-    assert fs.total_size_bytes == int(1024**3)
+@pytest.mark.parametrize(
+    ("unit_str", "expected_total_bytes"),
+    [
+        ("B", 3),
+        ("K", 3 * 1024),
+        ("KB", 3e3),
+        ("kB", 3e3),
+        ("kb", 3e3),
+        ("Ki", 3 * 1024),
+        ("ki", 3 * 1024),
+        ("M", 3 * (1024**2)),
+        ("MB", 3e6),
+        ("mB", 3e6),
+        ("mb", 3e6),
+        ("Mi", 3 * (1024**2)),
+        ("mi", 3 * (1024**2)),
+        ("G", 3 * (1024**3)),
+        ("GB", 3e9),
+        ("gB", 3e9),
+        ("gb", 3e9),
+        ("Gi", 3 * (1024**3)),
+        ("gi", 3 * (1024**3)),
+    ],
+)
+def test_file_size_minimally_works(expected_total_bytes, unit_str):
+    fs = _FileSize(num=3.0, unit_str=unit_str)
+    assert fs.total_size_bytes == int(expected_total_bytes)
 
 
 def test_file_size_comparisons_work():


### PR DESCRIPTION
fixes #274

Some configuration options, like `--max-allowed-size-compressed`, allow you to change file-size-based thresholds that influence check results.

These are currently evaluated in "bibytes", but are not correctly document. e.g. `"1M" = "1 mebibyte" = 1024^2 bytes`, but `pydistcheck` docs say that `"1M" = "1 megabyte"`, which is 1,000,000 bytes.

This PR:

* fixes those docs
* adds support for using the clearer form like `Mi` or `Gi`
* adds support for really specifying sizes in other units, like `"MB"` for megabytes
* ignores case, so that now these would all evaluate to the same number of bytes: `5KB, 5kB, 5Kb, 5kb`

## Why have the single-letter aliases like `M` support e.g. mebibytes instead of megabytes

To avoid breaking any existing `pydistcheck` uses that have been relying on that behavior.

And because I couldn't find any reference suggesting a preferred way to interpret the unit `M`.