### PR TITLE
set floors on runtime dependencies (fixes #272)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,8 @@ repos:
         args: ["--config-file", "pyproject.toml"]
         exclude: "tests"
         additional_dependencies:
-          - click
-          - tomli
+          - click>=8.0
+          - tomli>=1.1.0
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
@@ -49,6 +49,6 @@ repos:
       - id: rstcheck
         args: ["--config=pyproject.toml"]
         additional_dependencies:
-          - click
+          - click>=8.0
           - sphinx>=7.3
           - sphinx-click>=6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
     "Topic :: Utilities"
 ]
 dependencies = [
-    "click",
-    "tomli ; python_version < '3.11'"
+    "click>=8.0",
+    "tomli>=1.1.0 ; python_version < '3.11'"
 ]
 description = "Inspect Python package distributions and raise warnings on common problems."
 keywords = [


### PR DESCRIPTION
fixes #272 

Sets runtime floors on this project's dependencies:

* `click 8.0.0` ([May 2021](https://pypi.org/project/click/8.0.0/))
* `tomli 1.1.0` ([July 2021](https://pypi.org/project/tomli/1.1.0/))

## Notes for Reviewers

### How I found those

Installed the oldest versions on PyPI, and ran the following:

```shell
pydistcheck --help
pydistcheck --version
pydistcheck --inspect ./tests/data/*.whl
make test-local
```

When those broke, tried newer versions.

I kept working up from there until I found versions that this project was compatible with.