### PR TITLE
[ci] use yamllint, update pre-commit hooks

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-check.yml
+++ b/.github/ISSUE_TEMPLATE/new-check.yml
@@ -33,7 +33,8 @@ body:
       label: Will this check introduce any additional configuration?
       description: |
         For example, the `too-many-files` checks introduced configuration option
-        `--max-allowed-files` to allow user control over how many files are allowed in a distribution.
+        `--max-allowed-files` to allow user control over how many files are allowed
+        in a distribution.
       options:
         - 'yes'
         - 'no'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,8 +24,5 @@ jobs:
           conda install \
             --yes \
             -c conda-forge \
-              pre-commit \
-              requests \
-              types-requests \
-              yamllint
+              pre-commit
           make lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.7.2
+    rev: v0.8.0
     hooks:
       # Run the linter.
       - id: ruff
@@ -52,3 +52,7 @@ repos:
           - click>=8.0
           - sphinx>=7.3
           - sphinx-click>=6.0
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,22 @@
+extends: default
+
+rules:
+  anchors:
+    forbid-undeclared-aliases: true
+    forbid-duplicated-anchors: true
+    forbid-unused-anchors: true
+  braces:
+    forbid: false
+    min-spaces-inside: 0
+    # allow 1 space for jinja templating in conda recipes
+    max-spaces-inside: 1
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  line-length:
+    max: 120
+  truthy:
+    allowed-values: ['false', 'true']
+    # having problematic value in keys is rare... and also
+    # GitHub Actions' choie of 'on:' triggers this check
+    # ref: https://github.com/adrienverge/yamllint/issues/430
+    check-keys: false

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,6 @@ install:
 .PHONY: lint
 lint:
 	pre-commit run --all-files
-	yamllint \
-		--strict \
-		-d '{extends: default, rules: {braces: {max-spaces-inside: 1}, truthy: {check-keys: false}, line-length: {max: 120}}}' \
-		.
 
 .PHONY: linux-wheel
 linux-wheel:

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 [![PyPI Version](https://img.shields.io/pypi/v/pydistcheck.svg?logo=pypi&logoColor=white)](https://pypi.org/project/pydistcheck)
 [![PyPI downloads](https://static.pepy.tech/badge/pydistcheck)](https://pypi.org/project/pydistcheck)
 [![Documentation Status](https://readthedocs.org/projects/pydistcheck/badge/?version=latest)](https://pydistcheck.readthedocs.io/)
-[![GitHub Actions](https://github.com/jameslamb/pydistcheck/workflows/unit-tests/badge.svg?branch=main)](https://github.com/jameslamb/pydistcheck/actions/workflows/unit-tests.yml)
-[![GitHub Actions](https://github.com/jameslamb/pydistcheck/workflows/smoke-tests/badge.svg?branch=main)](https://github.com/jameslamb/pydistcheck/actions/workflows/smoke-tests.yml)
+[![GitHub Actions](https://github.com/jameslamb/pydistcheck/actions/workflows/unit-tests.yml/badge.svg?branch=main)](https://github.com/jameslamb/pydistcheck/actions/workflows/unit-tests.yml)
+[![GitHub Actions](https://github.com/jameslamb/pydistcheck/actions/workflows/smoke-tests.yml/badge.svg?branch=main)](https://github.com/jameslamb/pydistcheck/actions/workflows/smoke-tests.yml)
+
+https://github.com/microsoft/LightGBM/actions/workflows/python_package.yml/badge.svg?branch=master
 
 ## What is `pydistcheck`?
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 [![GitHub Actions](https://github.com/jameslamb/pydistcheck/actions/workflows/unit-tests.yml/badge.svg?branch=main)](https://github.com/jameslamb/pydistcheck/actions/workflows/unit-tests.yml)
 [![GitHub Actions](https://github.com/jameslamb/pydistcheck/actions/workflows/smoke-tests.yml/badge.svg?branch=main)](https://github.com/jameslamb/pydistcheck/actions/workflows/smoke-tests.yml)
 
-https://github.com/microsoft/LightGBM/actions/workflows/python_package.yml/badge.svg?branch=master
-
 ## What is `pydistcheck`?
 
 `pydistcheck` is a command line interface (CLI) that you run on Python packages, which can:

--- a/src/pydistcheck/_compat.py
+++ b/src/pydistcheck/_compat.py
@@ -24,4 +24,4 @@ def _import_zstandard() -> Any:
         raise ModuleNotFoundError(err_msg) from err
 
 
-__all__ = ["tomllib", "_import_zstandard"]
+__all__ = ["_import_zstandard", "tomllib"]


### PR DESCRIPTION
Some miscellaneous development changes:

* adds `yamllint` linting
* updates all `pre-commit` hooks to their latest versions (`pre-commit autoupdate`)
* fixes GitHub Actions badges in the README
  - *the `smoke-tests` one was displaying the wrong status... switched to the pattern from https://github.com/microsoft/LightGBM/pull/6570*