### PR TITLE
[docs] improve zstandard error message

### DIFF
--- a/src/pydistcheck/_compat.py
+++ b/src/pydistcheck/_compat.py
@@ -19,7 +19,7 @@ def _import_zstandard() -> Any:
     except ModuleNotFoundError as err:
         err_msg = (
             "Checking zstd-compressed files requires the 'zstandard' library. "
-            "Install it with e.g. 'pip install zstandard'."
+            "Install it with e.g. 'pip install zstandard' or 'conda install conda-forge::zstandard'."
         )
         raise ModuleNotFoundError(err_msg) from err
 


### PR DESCRIPTION
Fixes #284

Replaces #285 and #286

~I decided to delete the previously made branch release/v0.8.1 as the change did not warrant an immediate release. This PR has been created in its place.~

Added the command to install the zstandard package using conda.