### PR TITLE
Correctly vendor `delocate` license in wheels

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022, James Lamb
+Copyright (c) 2022-2025, James Lamb
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-graft LICENSES

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ keywords = [
     "python-packaging",
     "testing"
 ]
-license = {file = "LICENSE"}
 maintainers = [
   {name = "James Lamb", email = "jaylamb20@gmail.com"}
 ]
@@ -43,6 +42,13 @@ name = "pydistcheck"
 readme = "README.md"
 requires-python = ">=3.8"
 dynamic = ["version"]
+
+[tool.setuptools]
+# include-package-data = true
+license-files = [
+    "LICENSE",
+    "LICENSES/*"
+]
 
 [tool.setuptools.dynamic]
 version = {attr = "pydistcheck.__version__"}
@@ -64,7 +70,7 @@ changelog = "https://github.com/jameslamb/pydistcheck/releases"
 [build-system]
 
 requires = [
-    "setuptools>=67",
+    "setuptools>=75.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/src/pydistcheck/file_utils.py
+++ b/src/pydistcheck/file_utils.py
@@ -123,7 +123,7 @@ def _guess_archive_member_file_format(
     """
     The approach in this function was inspired by similar code in
     https://github.com/matthew-brett/delocate, so that project's license is included
-    in distributions of ``pydistcheck`` at path ``LICENSES/DELOCATE_LICENSE``.
+    in distributions of ``pydistcheck`` as file ``DELOCATE_LICENSE``.
 
     Returns a two-item tuple of the form ``(file_format, is_compiled)``.
     """


### PR DESCRIPTION
This project has a bit of code copied from https://github.com/matthew-brett/delocate, and so vendors that project's license file. I realized today that that that is not being included in wheels here (only sdists).

Looks like that's because the mechanism this project is using is `MANIFEST.in`, which isn't affecting wheels in the way this project is currently configured.

This PR proposes:

* stop using `MANIFEST.in`
* use `setuptools` `license-files` mechanism to include licenses (https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html)