### PR TITLE
[ci] add workflow to check PR labels

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,4 +1,4 @@
-name: Label Checker
+name: check-labels
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
@@ -6,7 +6,7 @@ on:
   pull_request_target:
     types: [opened, labeled, reopened, synchronize]
 jobs:
-  label:
+  check:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/label-checker.yml
+++ b/.github/workflows/label-checker.yml
@@ -1,0 +1,27 @@
+name: Label Checker
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+  # include PRs from forks
+  pull_request_target:
+    types: [opened, labeled, reopened, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          add_comment: false
+          count: 1
+          # this should match release-drafter.yml
+          labels: |
+            breaking
+            doc
+            enhancement
+            fix
+            maintenance


### PR DESCRIPTION
Adds a workflow to enforce that every PR has exactly 1 of the required labels.

To ensure they're all categorized in release notes correctly, matching this:

https://github.com/jameslamb/pydistcheck/blob/127264dbfb6a68c2d2403db82e0bc5331744f61e/.github/release-drafter.yml#L4-L14

## Notes for Reviewers

docs: https://github.com/mheap/github-action-required-labels