### PR TITLE
make output file size units configurable

### DIFF
--- a/docs/_static/defaults.toml
+++ b/docs/_static/defaults.toml
@@ -38,6 +38,13 @@ max_allowed_size_uncompressed = '75M'
 # https://pydistcheck.readthedocs.io/en/latest/check-reference.html#path-too-long
 max_path_length = 200
 
+# Units to use in output that reports file sizes.
+#
+# If 'auto' (the default), units are adjusted based on the total size.
+#
+# See 'pydistcheck --help' for available units.
+output_file_size_unit = 'auto'
+
 # List of fnmatch.fnmatchcase() patterns to be compared to directories
 # in the distribution.
 expected_directories = [

--- a/src/pydistcheck/_checks.py
+++ b/src/pydistcheck/_checks.py
@@ -77,17 +77,20 @@ class _CompiledObjectsDebugSymbolCheck(_CheckProtocol):
 class _DistroTooLargeCompressedCheck(_CheckProtocol):
     check_name = "distro-too-large-compressed"
 
-    def __init__(self, max_allowed_size_bytes: int):
+    def __init__(self, max_allowed_size_bytes: int, output_file_size_unit: str):
         self.max_allowed_size_bytes = max_allowed_size_bytes
+        self.output_file_size_unit = output_file_size_unit
 
     def __call__(self, distro_summary: _DistributionSummary) -> List[str]:
         out: List[str] = []
         max_size = _FileSize(num=self.max_allowed_size_bytes, unit_str="B")
         actual_size = _FileSize(num=distro_summary.compressed_size_bytes, unit_str="B")
         if actual_size > max_size:
+            actual_size_str = actual_size.to_string(unit_str=self.output_file_size_unit)
+            max_size_str = max_size.to_string(unit_str=self.output_file_size_unit)
             msg = (
-                f"[{self.check_name}] Compressed size {actual_size} is larger "
-                f"than the allowed size ({max_size})."
+                f"[{self.check_name}] Compressed size {actual_size_str} is larger "
+                f"than the allowed size ({max_size_str})."
             )
             out.append(msg)
         return out
@@ -96,8 +99,9 @@ class _DistroTooLargeCompressedCheck(_CheckProtocol):
 class _DistroTooLargeUnCompressedCheck(_CheckProtocol):
     check_name = "distro-too-large-uncompressed"
 
-    def __init__(self, max_allowed_size_bytes: int):
+    def __init__(self, max_allowed_size_bytes: int, output_file_size_unit: str):
         self.max_allowed_size_bytes = max_allowed_size_bytes
+        self.output_file_size_unit = output_file_size_unit
 
     def __call__(self, distro_summary: _DistributionSummary) -> List[str]:
         out: List[str] = []
@@ -106,9 +110,11 @@ class _DistroTooLargeUnCompressedCheck(_CheckProtocol):
             num=distro_summary.uncompressed_size_bytes, unit_str="B"
         )
         if actual_size > max_size:
+            actual_size_str = actual_size.to_string(unit_str=self.output_file_size_unit)
+            max_size_str = max_size.to_string(unit_str=self.output_file_size_unit)
             msg = (
-                f"[{self.check_name}] Uncompressed size {actual_size} is larger "
-                f"than the allowed size ({max_size})."
+                f"[{self.check_name}] Uncompressed size {actual_size_str} is larger "
+                f"than the allowed size ({max_size_str})."
             )
             out.append(msg)
         return out

--- a/src/pydistcheck/_config.py
+++ b/src/pydistcheck/_config.py
@@ -24,6 +24,7 @@ _ALLOWED_CONFIG_VALUES = {
     "max_allowed_size_compressed",
     "max_allowed_size_uncompressed",
     "max_path_length",
+    "output_file_size_unit",
     "select",
 }
 
@@ -68,6 +69,7 @@ class _Config:
     max_allowed_size_compressed: str = "50M"
     max_allowed_size_uncompressed: str = "75M"
     max_path_length: int = 200
+    output_file_size_unit: str = "auto"
     select: Sequence[str] = ()
 
     def __setattr__(self, name: str, value: Any) -> None:

--- a/src/pydistcheck/_inspect.py
+++ b/src/pydistcheck/_inspect.py
@@ -7,15 +7,17 @@ from typing import TYPE_CHECKING
 from ._utils import _FileSize
 
 if TYPE_CHECKING:
+    from ._config import _Config
     from .distribution_summary import _DistributionSummary
 
 
-def inspect_distribution(summary: "_DistributionSummary") -> None:
+def inspect_distribution(*, summary: "_DistributionSummary", config: "_Config") -> None:
     print("file size")
+    unit_str = config.output_file_size_unit
     compressed_size = _FileSize(summary.compressed_size_bytes, "B")
     uncompressed_size = _FileSize(summary.uncompressed_size_bytes, "B")
-    print(f"  * compressed size: {compressed_size}")
-    print(f"  * uncompressed size: {uncompressed_size}")
+    print(f"  * compressed size: {compressed_size.to_string(unit_str=unit_str)}")
+    print(f"  * uncompressed size: {uncompressed_size.to_string(unit_str=unit_str)}")
     space_saving = 1.0 - (
         compressed_size.total_size_bytes / uncompressed_size.total_size_bytes
     )
@@ -28,11 +30,13 @@ def inspect_distribution(summary: "_DistributionSummary") -> None:
     print("size by extension")
     for extension, size in summary.size_by_file_extension.items():
         size_pct = size / summary.uncompressed_size_bytes
-        print(f"  * {extension} - {_FileSize(size, 'B')} ({round(size_pct * 100, 1)}%)")
+        print(
+            f"  * {extension} - {_FileSize(size, 'B').to_string(unit_str=unit_str)} ({round(size_pct * 100, 1)}%)"
+        )
 
     largest_files = summary.get_largest_files(n=5)
     print("largest files")
     for file_info in largest_files:
         print(
-            f"  * ({_FileSize(file_info.uncompressed_size_bytes, 'B')}) {file_info.name}"
+            f"  * ({_FileSize(file_info.uncompressed_size_bytes, 'B').to_string(unit_str=unit_str)}) {file_info.name}"
         )

--- a/src/pydistcheck/_utils.py
+++ b/src/pydistcheck/_utils.py
@@ -58,7 +58,7 @@ class _FileSize:
         if unit_str == "auto":
             num, unit_str = _recommend_size_str(self.total_size_bytes)
         else:
-            num = self.total_size_bytes / _UNIT_TO_NUM_BYTES[unit_str]
+            num = self.total_size_bytes / _UNIT_TO_NUM_BYTES[unit_str.lower()]
         return f"{round(num, 3)}{unit_str}"
 
     @property

--- a/src/pydistcheck/_utils.py
+++ b/src/pydistcheck/_utils.py
@@ -37,9 +37,10 @@ def _recommend_size_str(num_bytes: int) -> Tuple[float, str]:
 
 
 class _FileSize:
-    def __init__(self, num: float, unit_str: str):
+    def __init__(self, num: float, unit_str: str, output_unit_str: str = "auto"):
         self._num = num
         self._unit_str = unit_str
+        self._output_unit_str = output_unit_str
 
     @classmethod
     def from_number(cls, num: int) -> "_FileSize":
@@ -52,6 +53,13 @@ class _FileSize:
         if parsed is None:
             raise ValueError(f"Could not parse '{size_str}' as a file size.")
         return cls(num=float(parsed.group(1)), unit_str=parsed.group(2))
+
+    def to_string(self, unit_str: str) -> str:
+        if unit_str == "auto":
+            num, unit_str = _recommend_size_str(self.total_size_bytes)
+        else:
+            num = self.total_size_bytes / _UNIT_TO_NUM_BYTES[unit_str]
+        return f"{round(num, 3)}{unit_str}"
 
     @property
     def total_size_bytes(self) -> int:
@@ -79,5 +87,4 @@ class _FileSize:
         return not self == other
 
     def __str__(self) -> str:
-        num_bytes, unit_str = _recommend_size_str(self.total_size_bytes)
-        return f"{round(num_bytes, 3)}{unit_str}"
+        return self.to_string(unit_str="auto")

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -258,12 +258,14 @@ def check(  # noqa: PLR0913
         _DistroTooLargeCompressedCheck(
             max_allowed_size_bytes=_FileSize.from_string(
                 size_str=conf.max_allowed_size_compressed
-            ).total_size_bytes
+            ).total_size_bytes,
+            output_file_size_unit=conf.output_file_size_unit,
         ),
         _DistroTooLargeUnCompressedCheck(
             max_allowed_size_bytes=_FileSize.from_string(
                 size_str=conf.max_allowed_size_uncompressed
-            ).total_size_bytes
+            ).total_size_bytes,
+            output_file_size_unit=conf.output_file_size_unit,
         ),
         _ExpectedFilesCheck(
             directory_patterns=expected_directories,

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -161,6 +161,23 @@ class ExitCodes:
     type=int,
     help="Maximum allowed filepath length for files or directories in the distribution.",
 )
+@click.option(
+    "--output-file-size-unit",
+    default=_Config.output_file_size_unit,
+    show_default=True,
+    type=str,
+    help=(
+        "Unit for all file sizes reported in outputs (e.g. log messages, --inspect output)"
+        " Supported units:\n"
+        "  - B = bytes\n"
+        "  - KB = kilobytes\n"
+        "  - K, Ki = kibibytes\n"
+        "  - MB = megabytes\n"
+        "  - M, Mi = mebibytes\n"
+        "  - GB = gigabytes\n"
+        "  - G, Gi = gibibytes"
+    ),
+)
 def check(  # noqa: PLR0913
     *,
     filepaths: str,
@@ -174,6 +191,7 @@ def check(  # noqa: PLR0913
     max_allowed_size_compressed: str,
     max_allowed_size_uncompressed: str,
     max_path_length: int,
+    output_file_size_unit: str,
     select: Sequence[str],
 ) -> None:
     """
@@ -199,6 +217,7 @@ def check(  # noqa: PLR0913
         "max_allowed_size_compressed": max_allowed_size_compressed,
         "max_allowed_size_uncompressed": max_allowed_size_uncompressed,
         "max_path_length": max_path_length,
+        "output_file_size_unit": output_file_size_unit,
         "select": select,
         "expected_directories": expected_directories,
         "expected_files": expected_files,
@@ -281,7 +300,10 @@ def check(  # noqa: PLR0913
 
         if conf.inspect:
             print("----- package inspection summary -----")
-            inspect_distribution(summary)
+            inspect_distribution(
+                summary=summary,
+                config=conf,
+            )
 
         print("------------ check results -----------")
         errors: List[str] = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -454,6 +454,37 @@ def test_check_respects_max_allowed_size_compressed(size_str, distro_file):
     _assert_log_matches_pattern(result, "errors found while checking\\: 1")
 
 
+@pytest.mark.parametrize("unit_str", ["B", "K", "KB", "Mi", "GB", "Gi"])
+def test_check_error_messages_supports_output_file_size_unit(unit_str):
+    runner = CliRunner()
+    result = runner.invoke(
+        check,
+        [
+            os.path.join(TEST_DATA_DIR, BASE_PACKAGES[1]),
+            "--max-allowed-size-compressed=1B",
+            "--max-allowed-size-uncompressed=1B",
+            f"--output-file-size-unit={unit_str}",
+        ],
+    )
+    assert result.exit_code == 1
+
+    _assert_log_matches_pattern(
+        result,
+        (
+            rf"^1\. \[distro\-too\-large\-compressed\] Compressed size [0-9]+\.[0-9]+{unit_str} is "
+            rf"larger than the allowed size \([0-9]+\.[0-9]+{unit_str}\)\.$"
+        ),
+    )
+    _assert_log_matches_pattern(
+        result,
+        (
+            rf"^2\. \[distro\-too\-large\-uncompressed\] Uncompressed size [0-9]+\.[0-9]+{unit_str} is "
+            rf"larger than the allowed size \([0-9]+\.[0-9]+{unit_str}\)\.$"
+        ),
+    )
+    _assert_log_matches_pattern(result, "errors found while checking\\: 2")
+
+
 @pytest.mark.parametrize(
     "size_str",
     [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1039,3 +1039,44 @@ def test_inspect_runs_before_checks(distro_file):
     )
     _assert_log_matches_pattern(result, "errors found while checking\\: 1")
     _assert_log_matches_pattern(result, r"^size by extension$")
+
+
+def test_inspect_respects_output_file_size_unit_for_all_size_strings():
+    distro_file = os.path.join(TEST_DATA_DIR, BASE_PACKAGES[0])
+
+    # --output-file-size-unit auto
+    result = CliRunner().invoke(
+        check,
+        [
+            "--inspect",
+            distro_file,
+        ],
+    )
+    assert result.exit_code == 0
+
+    # mix of B and K
+    _assert_log_matches_pattern(result, r" compressed size: 4\.938K")
+    _assert_log_matches_pattern(result, r" uncompressed size: 12\.039K")
+    _assert_log_matches_pattern(result, r" \.py \- 70\.0B")
+    _assert_log_matches_pattern(
+        result, r" \(11\.092K\) base-package\-0\.1\.0/LICENSE\.txt"
+    )
+
+    # --output-file-size-unit B
+    result = CliRunner().invoke(
+        check,
+        [
+            "--inspect",
+            "--output-file-size-unit=B",
+            os.path.join(TEST_DATA_DIR, distro_file),
+        ],
+    )
+    assert result.exit_code == 0
+
+    # all B
+    _assert_log_matches_pattern(result, r" compressed size: 5057\.0B")
+    _assert_log_matches_pattern(result, r" uncompressed size: 12328\.0B")
+    _assert_log_matches_pattern(result, r" \.py \- 70\.0B")
+    _assert_log_matches_pattern(
+        result, r" \(11358\.0B\) base-package\-0\.1\.0/LICENSE\.txt"
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,6 +59,7 @@ def test_update_from_dict_works_when_changing_all_values(base_config):
     assert base_config.max_allowed_files == 7
     assert base_config.max_allowed_size_compressed == "1G"
     assert base_config.max_allowed_size_uncompressed == "18K"
+    assert base_config.output_file_size_unit == "auto"
     assert base_config.select == ()
     patch_dict = {
         "expected_directories": "!*/tests",
@@ -69,6 +70,7 @@ def test_update_from_dict_works_when_changing_all_values(base_config):
         "max_allowed_size_compressed": "2G",
         "max_allowed_size_uncompressed": "141K",
         "max_path_length": 600,
+        "output_file_size_unit": "GB",
         "select": ["distro-too-large-compressed"],
     }
     assert set(patch_dict.keys()) == _ALLOWED_CONFIG_VALUES, (
@@ -83,6 +85,7 @@ def test_update_from_dict_works_when_changing_all_values(base_config):
     assert base_config.max_allowed_size_compressed == "2G"
     assert base_config.max_allowed_size_uncompressed == "141K"
     assert base_config.max_path_length == 600
+    assert base_config.output_file_size_unit == "GB"
     assert base_config.select == ["distro-too-large-compressed"]
 
 
@@ -141,6 +144,7 @@ def test_update_from_toml_works_with_all_config_values(
         "max_allowed_size_compressed": "'3G'",
         "max_allowed_size_uncompressed": "'4.12G'",
         "max_path_length": 25,
+        "output_file_size_unit": "'Mi'",
         "select": "[\n'mixed-file-extensions',\n'path-contains-non-ascii-characters'\n]",
     }
     assert set(patch_dict.keys()) == _ALLOWED_CONFIG_VALUES, (
@@ -162,6 +166,7 @@ def test_update_from_toml_works_with_all_config_values(
     assert base_config.max_allowed_size_compressed == "3G"
     assert base_config.max_allowed_size_uncompressed == "4.12G"
     assert base_config.max_path_length == 25
+    assert base_config.output_file_size_unit == "Mi"
     assert base_config.select == [
         "mixed-file-extensions",
         "path-contains-non-ascii-characters",


### PR DESCRIPTION
Closes #280

Makes the units of file sizes appearing in output from `--inspect` and in log messages / errors configurable.

For example:

```shell
mkdir -p ./delete-me
pip download \
  --no-deps \
  -d ./delete-me \
  'pandas>2.0'
```

Default behavior:

```shell
pydistcheck \
    --inspect \
    --max-allowed-size-compressed '500K' \
    ./delete-me/pandas*.whl
```

```text
==================== running pydistcheck ====================

checking './delete-me/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl'
----- package inspection summary -----
file size
  * compressed size: 10.837M
  * uncompressed size: 38.545M
  * compression space saving: 71.9%
contents
  * directories: 154
  * files: 1509 (44 compiled)
size by extension
  * .py - 19.428M (50.4%)
  * .so - 18.699M (48.5%)
  * no-extension - 0.285M (0.7%)
  * .pyi - 0.101M (0.3%)
  * .toml - 23.883K (0.1%)
  * .tpl - 8.287K (0.0%)
  * .txt - 69.0B (0.0%)
largest files
  * (1.923M) pandas/_libs/groupby.cpython-312-darwin.so
  * (1.78M) pandas/_libs/hashtable.cpython-312-darwin.so
  * (1.626M) pandas/_libs/algos.cpython-312-darwin.so
  * (1.106M) pandas/_libs/interval.cpython-312-darwin.so
  * (1.015M) pandas/_libs/join.cpython-312-darwin.so
------------ check results -----------
1. [distro-too-large-compressed] Compressed size 10.837M is larger than the allowed size (0.488M).
errors found while checking: 1

==================== done running pydistcheck ===============
```

Configurable output size:

```shell
pydistcheck \
    --inspect \
    --max-allowed-size-compressed '500K' \
    --output-file-size-unit 'B' \
    ./delete-me/pandas*.whl
```

```text
==================== running pydistcheck ====================

checking './delete-me/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl'
----- package inspection summary -----
file size
  * compressed size: 11363475.0B
  * uncompressed size: 40417621.0B
  * compression space saving: 71.9%
contents
  * directories: 154
  * files: 1509 (44 compiled)
size by extension
  * .py - 20372023.0B (50.4%)
  * .so - 19607840.0B (48.5%)
  * no-extension - 298890.0B (0.7%)
  * .pyi - 105857.0B (0.3%)
  * .toml - 24456.0B (0.1%)
  * .tpl - 8486.0B (0.0%)
  * .txt - 69.0B (0.0%)
largest files
  * (2015904.0B) pandas/_libs/groupby.cpython-312-darwin.so
  * (1866320.0B) pandas/_libs/hashtable.cpython-312-darwin.so
  * (1705336.0B) pandas/_libs/algos.cpython-312-darwin.so
  * (1160032.0B) pandas/_libs/interval.cpython-312-darwin.so
  * (1064296.0B) pandas/_libs/join.cpython-312-darwin.so
------------ check results -----------
1. [distro-too-large-compressed] Compressed size 11363475.0B is larger than the allowed size (512000.0B).
errors found while checking: 1

==================== done running pydistcheck ===============
```
