### PR TITLE
make output file size precision configurable

### DIFF
--- a/docs/_static/defaults.toml
+++ b/docs/_static/defaults.toml
@@ -38,6 +38,10 @@ max_allowed_size_uncompressed = '75M'
 # https://pydistcheck.readthedocs.io/en/latest/check-reference.html#path-too-long
 max_path_length = 200
 
+# Number of significant digits to use when rounding file sizes
+# in printed output.
+output_file_size_precision = 3
+
 # Units to use in output that reports file sizes.
 #
 # If 'auto' (the default), units are adjusted based on the total size.

--- a/src/pydistcheck/_checks.py
+++ b/src/pydistcheck/_checks.py
@@ -77,8 +77,15 @@ class _CompiledObjectsDebugSymbolCheck(_CheckProtocol):
 class _DistroTooLargeCompressedCheck(_CheckProtocol):
     check_name = "distro-too-large-compressed"
 
-    def __init__(self, *, max_allowed_size_bytes: int, output_file_size_unit: str):
+    def __init__(
+        self,
+        *,
+        max_allowed_size_bytes: int,
+        output_file_size_precision: int,
+        output_file_size_unit: str,
+    ):
         self.max_allowed_size_bytes = max_allowed_size_bytes
+        self.output_file_size_precision = output_file_size_precision
         self.output_file_size_unit = output_file_size_unit
 
     def __call__(self, distro_summary: _DistributionSummary) -> List[str]:
@@ -86,8 +93,14 @@ class _DistroTooLargeCompressedCheck(_CheckProtocol):
         max_size = _FileSize(num=self.max_allowed_size_bytes, unit_str="B")
         actual_size = _FileSize(num=distro_summary.compressed_size_bytes, unit_str="B")
         if actual_size > max_size:
-            actual_size_str = actual_size.to_string(unit_str=self.output_file_size_unit)
-            max_size_str = max_size.to_string(unit_str=self.output_file_size_unit)
+            actual_size_str = actual_size.to_string(
+                precision=self.output_file_size_precision,
+                unit_str=self.output_file_size_unit,
+            )
+            max_size_str = max_size.to_string(
+                precision=self.output_file_size_precision,
+                unit_str=self.output_file_size_unit,
+            )
             msg = (
                 f"[{self.check_name}] Compressed size {actual_size_str} is larger "
                 f"than the allowed size ({max_size_str})."
@@ -99,8 +112,15 @@ class _DistroTooLargeCompressedCheck(_CheckProtocol):
 class _DistroTooLargeUnCompressedCheck(_CheckProtocol):
     check_name = "distro-too-large-uncompressed"
 
-    def __init__(self, *, max_allowed_size_bytes: int, output_file_size_unit: str):
+    def __init__(
+        self,
+        *,
+        max_allowed_size_bytes: int,
+        output_file_size_precision: int,
+        output_file_size_unit: str,
+    ):
         self.max_allowed_size_bytes = max_allowed_size_bytes
+        self.output_file_size_precision = output_file_size_precision
         self.output_file_size_unit = output_file_size_unit
 
     def __call__(self, distro_summary: _DistributionSummary) -> List[str]:
@@ -110,8 +130,14 @@ class _DistroTooLargeUnCompressedCheck(_CheckProtocol):
             num=distro_summary.uncompressed_size_bytes, unit_str="B"
         )
         if actual_size > max_size:
-            actual_size_str = actual_size.to_string(unit_str=self.output_file_size_unit)
-            max_size_str = max_size.to_string(unit_str=self.output_file_size_unit)
+            actual_size_str = actual_size.to_string(
+                precision=self.output_file_size_precision,
+                unit_str=self.output_file_size_unit,
+            )
+            max_size_str = max_size.to_string(
+                precision=self.output_file_size_precision,
+                unit_str=self.output_file_size_unit,
+            )
             msg = (
                 f"[{self.check_name}] Uncompressed size {actual_size_str} is larger "
                 f"than the allowed size ({max_size_str})."

--- a/src/pydistcheck/_config.py
+++ b/src/pydistcheck/_config.py
@@ -24,6 +24,7 @@ _ALLOWED_CONFIG_VALUES = {
     "max_allowed_size_compressed",
     "max_allowed_size_uncompressed",
     "max_path_length",
+    "output_file_size_precision",
     "output_file_size_unit",
     "select",
 }
@@ -69,6 +70,7 @@ class _Config:
     max_allowed_size_compressed: str = "50M"
     max_allowed_size_uncompressed: str = "75M"
     max_path_length: int = 200
+    output_file_size_precision: int = 3
     output_file_size_unit: str = "auto"
     select: Sequence[str] = ()
 

--- a/src/pydistcheck/_inspect.py
+++ b/src/pydistcheck/_inspect.py
@@ -14,10 +14,24 @@ if TYPE_CHECKING:
 def inspect_distribution(*, summary: "_DistributionSummary", config: "_Config") -> None:
     print("file size")
     unit_str = config.output_file_size_unit
-    compressed_size = _FileSize(summary.compressed_size_bytes, "B")
-    uncompressed_size = _FileSize(summary.uncompressed_size_bytes, "B")
-    print(f"  * compressed size: {compressed_size.to_string(unit_str=unit_str)}")
-    print(f"  * uncompressed size: {uncompressed_size.to_string(unit_str=unit_str)}")
+    compressed_size = _FileSize(
+        num=summary.compressed_size_bytes,
+        unit_str="B",
+    )
+    compressed_size_str = compressed_size.to_string(
+        precision=config.output_file_size_precision,
+        unit_str=unit_str,
+    )
+    uncompressed_size = _FileSize(
+        num=summary.uncompressed_size_bytes,
+        unit_str="B",
+    )
+    uncompressed_size_str = uncompressed_size.to_string(
+        precision=config.output_file_size_precision,
+        unit_str=unit_str,
+    )
+    print(f"  * compressed size: {compressed_size_str}")
+    print(f"  * uncompressed size: {uncompressed_size_str}")
     space_saving = 1.0 - (
         compressed_size.total_size_bytes / uncompressed_size.total_size_bytes
     )
@@ -30,13 +44,17 @@ def inspect_distribution(*, summary: "_DistributionSummary", config: "_Config") 
     print("size by extension")
     for extension, size in summary.size_by_file_extension.items():
         size_pct = size / summary.uncompressed_size_bytes
-        print(
-            f"  * {extension} - {_FileSize(size, 'B').to_string(unit_str=unit_str)} ({round(size_pct * 100, 1)}%)"
-        )
+        size_str = _FileSize(
+            num=size,
+            unit_str="B",
+        ).to_string(precision=config.output_file_size_precision, unit_str=unit_str)
+        print(f"  * {extension} - {size_str} ({round(size_pct * 100, 1)}%)")
 
     largest_files = summary.get_largest_files(n=5)
     print("largest files")
     for file_info in largest_files:
-        print(
-            f"  * ({_FileSize(file_info.uncompressed_size_bytes, 'B').to_string(unit_str=unit_str)}) {file_info.name}"
-        )
+        size_str = _FileSize(
+            num=file_info.uncompressed_size_bytes,
+            unit_str="B",
+        ).to_string(precision=config.output_file_size_precision, unit_str=unit_str)
+        print(f"  * ({size_str}) {file_info.name}")

--- a/src/pydistcheck/_utils.py
+++ b/src/pydistcheck/_utils.py
@@ -37,10 +37,14 @@ def _recommend_size_str(num_bytes: int) -> Tuple[float, str]:
 
 
 class _FileSize:
-    def __init__(self, num: float, unit_str: str, output_unit_str: str = "auto"):
+    def __init__(
+        self,
+        *,
+        num: float,
+        unit_str: str,
+    ):
         self._num = num
         self._unit_str = unit_str
-        self._output_unit_str = output_unit_str
 
     @classmethod
     def from_number(cls, num: int) -> "_FileSize":
@@ -54,12 +58,12 @@ class _FileSize:
             raise ValueError(f"Could not parse '{size_str}' as a file size.")
         return cls(num=float(parsed.group(1)), unit_str=parsed.group(2))
 
-    def to_string(self, unit_str: str) -> str:
+    def to_string(self, precision: int, unit_str: str) -> str:
         if unit_str == "auto":
             num, unit_str = _recommend_size_str(self.total_size_bytes)
         else:
             num = self.total_size_bytes / _UNIT_TO_NUM_BYTES[unit_str.lower()]
-        return f"{round(num, 3)}{unit_str}"
+        return f"{round(num, precision)}{unit_str}"
 
     @property
     def total_size_bytes(self) -> int:
@@ -87,4 +91,4 @@ class _FileSize:
         return not self == other
 
     def __str__(self) -> str:
-        return self.to_string(unit_str="auto")
+        return self.to_string(precision=3, unit_str="auto")

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -162,6 +162,15 @@ class ExitCodes:
     help="Maximum allowed filepath length for files or directories in the distribution.",
 )
 @click.option(
+    "--output-file-size-precision",
+    default=_Config.output_file_size_precision,
+    show_default=True,
+    type=int,
+    help=(
+        "Number of significant digits to use when rounding file sizes in printed output."
+    ),
+)
+@click.option(
     "--output-file-size-unit",
     default=_Config.output_file_size_unit,
     show_default=True,
@@ -191,6 +200,7 @@ def check(  # noqa: PLR0913
     max_allowed_size_compressed: str,
     max_allowed_size_uncompressed: str,
     max_path_length: int,
+    output_file_size_precision: int,
     output_file_size_unit: str,
     select: Sequence[str],
 ) -> None:
@@ -217,6 +227,7 @@ def check(  # noqa: PLR0913
         "max_allowed_size_compressed": max_allowed_size_compressed,
         "max_allowed_size_uncompressed": max_allowed_size_uncompressed,
         "max_path_length": max_path_length,
+        "output_file_size_precision": output_file_size_precision,
         "output_file_size_unit": output_file_size_unit,
         "select": select,
         "expected_directories": expected_directories,
@@ -259,12 +270,14 @@ def check(  # noqa: PLR0913
             max_allowed_size_bytes=_FileSize.from_string(
                 size_str=conf.max_allowed_size_compressed
             ).total_size_bytes,
+            output_file_size_precision=conf.output_file_size_precision,
             output_file_size_unit=conf.output_file_size_unit,
         ),
         _DistroTooLargeUnCompressedCheck(
             max_allowed_size_bytes=_FileSize.from_string(
                 size_str=conf.max_allowed_size_uncompressed
             ).total_size_bytes,
+            output_file_size_precision=conf.output_file_size_precision,
             output_file_size_unit=conf.output_file_size_unit,
         ),
         _ExpectedFilesCheck(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,6 +59,7 @@ def test_update_from_dict_works_when_changing_all_values(base_config):
     assert base_config.max_allowed_files == 7
     assert base_config.max_allowed_size_compressed == "1G"
     assert base_config.max_allowed_size_uncompressed == "18K"
+    assert base_config.output_file_size_precision == 3
     assert base_config.output_file_size_unit == "auto"
     assert base_config.select == ()
     patch_dict = {
@@ -70,6 +71,7 @@ def test_update_from_dict_works_when_changing_all_values(base_config):
         "max_allowed_size_compressed": "2G",
         "max_allowed_size_uncompressed": "141K",
         "max_path_length": 600,
+        "output_file_size_precision": 2,
         "output_file_size_unit": "GB",
         "select": ["distro-too-large-compressed"],
     }
@@ -85,6 +87,7 @@ def test_update_from_dict_works_when_changing_all_values(base_config):
     assert base_config.max_allowed_size_compressed == "2G"
     assert base_config.max_allowed_size_uncompressed == "141K"
     assert base_config.max_path_length == 600
+    assert base_config.output_file_size_precision == 2
     assert base_config.output_file_size_unit == "GB"
     assert base_config.select == ["distro-too-large-compressed"]
 
@@ -144,6 +147,7 @@ def test_update_from_toml_works_with_all_config_values(
         "max_allowed_size_compressed": "'3G'",
         "max_allowed_size_uncompressed": "'4.12G'",
         "max_path_length": 25,
+        "output_file_size_precision": 2,
         "output_file_size_unit": "'Mi'",
         "select": "[\n'mixed-file-extensions',\n'path-contains-non-ascii-characters'\n]",
     }
@@ -166,6 +170,7 @@ def test_update_from_toml_works_with_all_config_values(
     assert base_config.max_allowed_size_compressed == "3G"
     assert base_config.max_allowed_size_uncompressed == "4.12G"
     assert base_config.max_path_length == 25
+    assert base_config.output_file_size_precision == 2
     assert base_config.output_file_size_unit == "Mi"
     assert base_config.select == [
         "mixed-file-extensions",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -91,6 +91,32 @@ def test_file_size_from_number_switches_unit_str_based_on_size():
 
 
 @pytest.mark.parametrize(
+    ("precision", "unit_str", "expected_str"),
+    [
+        # 1 significant digit
+        (1, "B", "1234567.0B"),
+        (2, "B", "1234567.0B"),
+        (4, "B", "1234567.0B"),
+        (7, "B", "1234567.0B"),
+        # 3 significant digits
+        (1, "KB", "1234.6KB"),
+        (2, "KB", "1234.57KB"),
+        (4, "KB", "1234.567KB"),
+        (7, "KB", "1234.567KB"),
+        # 9 significant digits
+        (1, "GB", "0.0GB"),
+        (2, "GB", "0.0GB"),
+        (4, "GB", "0.0012GB"),
+        (7, "GB", "0.0012346GB"),
+        (9, "GB", "0.001234567GB"),
+    ],
+)
+def test_file_size_to_string_works(precision, unit_str, expected_str):
+    fs = _FileSize(num=1234567, unit_str="B")
+    assert fs.to_string(precision=precision, unit_str=unit_str) == expected_str
+
+
+@pytest.mark.parametrize(
     ("file_size", "expected_str"),
     [
         (_FileSize.from_number(110), "0.107K"),


### PR DESCRIPTION
Closes #297

Makes the precision of file sizes appearing in output from `--inspect` and in log messages / errors configurable.

For example:

```shell
mkdir -p ./delete-me
pip download \
  --no-deps \
  -d ./delete-me \
  'pandas>2.0'
```

Default behavior:

```shell
pydistcheck \
    --inspect \
    --max-allowed-size-compressed '500K' \
    ./delete-me/pandas*.whl
```

```text
==================== running pydistcheck ====================

checking './delete-me/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl'
----- package inspection summary -----
file size
  * compressed size: 10.837M
  * uncompressed size: 38.545M
  * compression space saving: 71.9%
contents
  * directories: 154
  * files: 1509 (44 compiled)
size by extension
  * .py - 19.428M (50.4%)
  * .so - 18.699M (48.5%)
  * no-extension - 0.285M (0.7%)
  * .pyi - 0.101M (0.3%)
  * .toml - 23.883K (0.1%)
  * .tpl - 8.287K (0.0%)
  * .txt - 69.0B (0.0%)
largest files
  * (1.923M) pandas/_libs/groupby.cpython-312-darwin.so
  * (1.78M) pandas/_libs/hashtable.cpython-312-darwin.so
  * (1.626M) pandas/_libs/algos.cpython-312-darwin.so
  * (1.106M) pandas/_libs/interval.cpython-312-darwin.so
  * (1.015M) pandas/_libs/join.cpython-312-darwin.so
------------ check results -----------
1. [distro-too-large-compressed] Compressed size 10.837M is larger than the allowed size (0.488M).
errors found while checking: 1

==================== done running pydistcheck ===============
```

Configurable output size:

```shell
pydistcheck \
    --inspect \
    --max-allowed-size-compressed '500K' \
    --output-file-size-precision 5 \
    ./delete-me/pandas*.whl
```

```text
==================== running pydistcheck ====================

checking './delete-me/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl'
----- package inspection summary -----
file size
  * compressed size: 10.83705M
  * uncompressed size: 38.54525M
  * compression space saving: 71.9%
contents
  * directories: 154
  * files: 1509 (44 compiled)
size by extension
  * .py - 19.42828M (50.4%)
  * .so - 18.69949M (48.5%)
  * no-extension - 0.28504M (0.7%)
  * .pyi - 0.10095M (0.3%)
  * .toml - 23.88281K (0.1%)
  * .tpl - 8.28711K (0.0%)
  * .txt - 69.0B (0.0%)
largest files
  * (1.92252M) pandas/_libs/groupby.cpython-312-darwin.so
  * (1.77986M) pandas/_libs/hashtable.cpython-312-darwin.so
  * (1.62634M) pandas/_libs/algos.cpython-312-darwin.so
  * (1.10629M) pandas/_libs/interval.cpython-312-darwin.so
  * (1.01499M) pandas/_libs/join.cpython-312-darwin.so
------------ check results -----------
1. [distro-too-large-compressed] Compressed size 10.83705M is larger than the allowed size (0.48828M).
errors found while checking: 1

==================== done running pydistcheck ===============
```