### PR TITLE
exclude hard-to-test codepaths from coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.report]
-fail_under = 99.5.0
+fail_under = 99.50
 exclude_also = [
     # skip type-checking blocks when calculating code coverage
     "if TYPE_CHECKING:"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.report]
-fail_under = 98.00
+fail_under = 99.5.0
 exclude_also = [
     # skip type-checking blocks when calculating code coverage
     "if TYPE_CHECKING:"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.report]
-fail_under = 99.50
+fail_under = 99.00
 exclude_also = [
     # skip type-checking blocks when calculating code coverage
     "if TYPE_CHECKING:"

--- a/src/pydistcheck/_compat.py
+++ b/src/pydistcheck/_compat.py
@@ -5,9 +5,9 @@ with a wide range of dependency versions.
 
 from typing import Any
 
-try:
+try:  # pragma: no cover
     import tomllib
-except ModuleNotFoundError:
+except ModuleNotFoundError:  # pragma: no cover
     import tomli as tomllib  # type: ignore[no-redef]
 
 

--- a/src/pydistcheck/_file_utils.py
+++ b/src/pydistcheck/_file_utils.py
@@ -132,7 +132,7 @@ def _guess_archive_member_file_format(
             header = f.read(4)
     else:
         fileobj = archive_file.extractfile(member_name)
-        if fileobj is None:
+        if fileobj is None:  # pragma: no cover
             error_msg = (
                 f"'{member_name}' not found. This is a bug in pydistcheck."
                 "Report it at https://github.com/jameslamb/pydistcheck/issues."

--- a/src/pydistcheck/_shared_lib_utils.py
+++ b/src/pydistcheck/_shared_lib_utils.py
@@ -82,7 +82,7 @@ def _file_has_debug_symbols(file_absolute_path: str) -> Tuple[bool, str]:
             tool_name=nm_tool,
             lib_file=file_absolute_path,
         )
-        if has_debug_symbols:
+        if has_debug_symbols:  # pragma: no cover
             return True, cmd_str
 
     # at this point, none of the checks found debug symbols


### PR DESCRIPTION
Excludes some hard-to-test codepaths from the coverage calculation, and raises the test coverage threshold.

ref: https://coverage.readthedocs.io/en/latest/excluding.html