### PR TITLE
Ignore `radr://5614542` remnant debug symbol for binaries stripped via Apple's `strip` utility

### DIFF
--- a/src/pydistcheck/_shared_lib_utils.py
+++ b/src/pydistcheck/_shared_lib_utils.py
@@ -10,6 +10,11 @@ _COMMAND_FAILED = "__command_failed__"
 _NO_DEBUG_SYMBOLS = "__no_debug_symbols_found__"
 _TOOL_NOT_AVAILABLE = "__tool_not_available__"
 
+# This specific debug symbol is added by Apple's "strip" on
+# Mach-O files and is a red herring for our purposes. See:
+# https://github.com/jameslamb/pydistcheck/issues/235
+_MACHO_STRIP_SYMBOL = "radr://5614542"
+
 
 def _run_command(args: List[str]) -> str:
     try:
@@ -58,7 +63,7 @@ def _look_for_debug_symbols(lib_file: str) -> Tuple[bool, str]:
 def _get_symbols(cmd_args: List[str], lib_file: str) -> str:
     syms = _run_command(args=[*cmd_args, lib_file])
     return "\n".join(
-        [line for line in syms.split("\n") if not (" a " in line or "\ta\t" in line)]
+        [line for line in syms.split("\n") if line and _MACHO_STRIP_SYMBOL not in line]
     )
 
 

--- a/src/pydistcheck/_shared_lib_utils.py
+++ b/src/pydistcheck/_shared_lib_utils.py
@@ -11,7 +11,7 @@ _NO_DEBUG_SYMBOLS = "__no_debug_symbols_found__"
 _TOOL_NOT_AVAILABLE = "__tool_not_available__"
 
 # This specific debug symbol is added by Apple's "strip" on
-# Mach-O files and is a red herring for our purposes. See:
+# Mach-O files and can safely be ignored for the purpose of detecting debug symbols. See:
 # https://github.com/jameslamb/pydistcheck/issues/235
 _MACHO_STRIP_SYMBOL = "radr://5614542"
 

--- a/tests/test_shared_lib_utils.py
+++ b/tests/test_shared_lib_utils.py
@@ -1,0 +1,23 @@
+from unittest.mock import Mock, patch
+
+from pydistcheck._shared_lib_utils import _MACHO_STRIP_SYMBOL, _get_symbols
+
+
+def test_get_symbols_filters_radr_symbol():
+    """Test that _get_symbols filters out the Mach-O strip symbol."""
+    mock_output = (
+        "0000000000000000 T _main\n"
+        f"0000000005614542 - 00 0000    OPT {_MACHO_STRIP_SYMBOL}\n"
+        "0000000000001000 D _data\n"
+    )
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = Mock(stdout=mock_output.encode())
+
+        result = _get_symbols(["nm", "-a"], "test.dylib")
+
+        # Should keep real symbols but filter out the strip symbol.
+        assert "_main" in result
+        assert "_data" in result
+        assert _MACHO_STRIP_SYMBOL not in result
+        assert len(result.split("\n")) == 2  # Only two real symbols


### PR DESCRIPTION
## Description

This PR closes #235; the "compiled-objects-have-debug-symbols" check was producing false positives for Mach-O files that have been passed through Apple's `strip`. This occurred because `strip` adds a specific weak symbol (`radr://5614542`) in Mach-O files that was detected as a debug symbol even in properly stripped binaries, even though it's just an artifact of the stripping process.

## Changes made

- modified the `_get_symbols` method to filter out this `radr://5614542` symbol in specific; and
- added a small test to verify the filtering behaviour.

## Additional context

Please refer to https://github.com/jameslamb/pydistcheck/issues/235#issuecomment-2561456586.