### PR TITLE
[ci] [docs] add link-checking in CI (fixes #293)

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -50,6 +50,7 @@ jobs:
             --timeout 10
             --max-retries 2
             --accept 200,429
+            --exclude-path docs/conf.py
             './**/*.rst'
             './**/*.md'
             './**/*.py'

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 jobs:
-  test:
+  check-docs:
     name: check-docs
     runs-on: ubuntu-latest
     steps:
@@ -28,3 +28,42 @@ jobs:
         run: |
           pip install .
           make -C ./docs html
+  check-links:
+    name: check-docs
+    runs-on: ubuntu-latest
+    steps:
+      # cache Lychee results to avoid hitting rate limits
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+      - uses: actions/checkout@v4
+      - name: Lychee URL checker
+        uses: lycheeverse/lychee-action@v2.3.0
+        with:
+          args: >-
+            --cache
+            --no-progress
+            --timeout 10
+            --max-retries 2
+            --accept 200,429
+            './**/*.rst'
+            './**/*.md'
+            './**/*.py'
+            './**/*.toml'
+            './**/*.yml'
+          # fail the action on broken links
+          fail: true
+          failIfEmpty: true
+  all-smoke-tests-successful:
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -28,8 +28,9 @@ jobs:
         run: |
           pip install .
           make -C ./docs html
+          python -m sphinx -b linkcheck -D linkcheck_timeout=5 --fail-on-warning ./docs ./linkcheck_output
   check-links:
-    name: check-docs
+    name: check-links
     runs-on: ubuntu-latest
     steps:
       # cache Lychee results to avoid hitting rate limits

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -57,11 +57,12 @@ jobs:
           # fail the action on broken links
           fail: true
           failIfEmpty: true
-  all-smoke-tests-successful:
+  all-docs-tests-successful:
     if: always()
     runs-on: ubuntu-latest
     needs:
-      - test
+      - check-docs
+      - check-links
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@v1.2.2

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ htmlcov/
 .idea/
 *.js
 *.json
+linkcheck_output/
+.lycheecache
 *.lzma
 .mypy_cache/
 *.npy

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,10 @@
+# URL-encoded form of a link with {} interpolation in
+# bin/get-conda-release-files.py
+https://api.anaconda.org/package/%7BCONDA_CHANNEL%7D
+
+# part of a regex in docs/conf.py
+https://github.com/pypi/support/blob/
+
+# special symbol added by 'strip' on macOS
+# (not actually a URL)
+radr://.*

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,9 +2,6 @@
 # bin/get-conda-release-files.py
 https://api.anaconda.org/package/%7BCONDA_CHANNEL%7D
 
-# part of a regex in docs/conf.py
-https://github.com/pypi/support/blob/
-
 # special symbol added by 'strip' on macOS
 # (not actually a URL)
 radr://.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.0
+    rev: v0.11.1
     hooks:
       # Run the linter.
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/isort
-    rev: 6.0.0
+    rev: 6.0.1
     hooks:
       - id: isort
         name: isort (python)
@@ -27,7 +27,7 @@ repos:
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.6
+    rev: v0.11.0
     hooks:
       # Run the linter.
       - id: ruff
@@ -37,7 +37,7 @@ repos:
         args: ["--config", "pyproject.toml"]
         types_or: [python, jupyter]
   - repo: https://github.com/maxwinterstein/shfmt-py
-    rev: v3.7.0.1
+    rev: v3.11.0.2
     hooks:
       - id: shfmt
         args: ["--indent=4", "--space-redirects", "--write"]
@@ -56,7 +56,7 @@ repos:
           - sphinx>=7.3
           - sphinx-click>=6.0
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
+    rev: v1.36.2
     hooks:
       - id: yamllint
         additional_dependencies: [pyyaml]
@@ -67,7 +67,7 @@ repos:
         additional_dependencies: [tomli]
         args: ["--toml", "pyproject.toml"]
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.23
+    rev: v0.24
     hooks:
       - id: validate-pyproject
   - repo: https://github.com/cheshirekow/cmake-format-precommit

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,8 @@ build:
   tools:
     python: "mambaforge-latest"
   jobs:
+    pre_build:
+      - python -m sphinx -b linkcheck -D linkcheck_timeout=5 --fail-on-warning ./docs/ ./linkcheck_output
     post_create_environment:
       - pip install .
 conda:

--- a/docs/_static/defaults.toml
+++ b/docs/_static/defaults.toml
@@ -77,6 +77,8 @@ expected_files = [
     '!*/.gitignore',
     '!*/.gitpod.yml',
     '!*/.hadolint.yaml',
+    '!*/.lycheecache',
+    '!*/.lycheeignore',
     '!*/.readthedocs.yaml',
     '!*/.travis.yml',
     '!*/vsts-ci.yml',

--- a/docs/check-reference.rst
+++ b/docs/check-reference.rst
@@ -148,7 +148,7 @@ Avoiding paths with spaces eliminates a whole class of potential issues related 
 
 For more information, see:
 
-* `"Long filenames or paths with spaces require quotation marks" (Windows docs) <https://learn.microsoft.com/en-us/troubleshoot/windows-server/deployment/filenames-with-spaces-require-quotation-mark>`_
+* `"Long filenames or paths with spaces require quotation marks" (Windows docs) <https://learn.microsoft.com/en-us/troubleshoot/windows-server/setup-upgrade-and-drivers/filenames-with-spaces-require-quotation-mark>`_
 * `"Don't use spaces or underscores in file paths" (blog post) <https://yihui.org/en/2018/03/space-pain/>`_
 * `"What technical reasons exist for not using space characters in file names?" (Stack Overflow) <https://superuser.com/questions/29111/what-technical-reasons-exist-for-not-using-space-characters-in-file-names>`_
 

--- a/docs/check-reference.rst
+++ b/docs/check-reference.rst
@@ -45,7 +45,7 @@ For a LOT more information about this topic, see these discussions in other open
 And these other resources.
 
 * `"Adding debugging information to your native extension" (memray docs) <https://bloomberg.github.io/memray/native_mode.html#adding-debugging-information-to-your-native-extension>`_
-* `"How can I tell if a binary was compiled with debug symbols?" (vscode-lldb docs) <https://github.com/vadimcn/vscode-lldb/wiki/How-can-I-tell-if-a-binary-was-compiled-with-debug-symbols%3F>`_
+* `"How can I tell if a binary was compiled with debug symbols?" (codelldb docs) <https://github.com/vadimcn/codelldb/wiki/How-can-I-tell-if-a-binary-was-compiled-with-debug-symbols%3F>`_
 
 distro-too-large-compressed
 ***************************
@@ -135,7 +135,7 @@ For more information, see:
 
 * `"Archives Containing Non-ASCII Filenames" (Oracle docs) <https://docs.oracle.com/cd/E36784_01/html/E36823/glnlx.html>`_
 * `example issue from pillow/PIL <https://github.com/python-pillow/Pillow/issues/5077>`_
-* `"Unix and non-ASCII file names, a summary of issues" <https://www.lesbonscomptes.com/recoll/faqsandhowtos/NonAsciiFileNames.html>`_
+* `"Unix and non-ASCII file names, a summary of issues" <https://www.recoll.org//faqsandhowtos/NonAsciiFileNames.html>`_
 * ``jqlang/jq#811``: `"File names with non ASCII characters" <https://github.com/jqlang/jq/issues/811>`_
 
 path-contains-spaces
@@ -185,7 +185,7 @@ See below for details.
 
     *This allows the* ``open()`` *function, the os module and most other path functionality to accept and return paths longer than 260 characters."*
 
-`Filename too long in Git for Windows (Stack Overflow answer) <https://stackoverflow.com/a/22575737/3986677>`__:
+`Filename too long in Git for Windows (Stack Overflow answer) <https://stackoverflow.com/questions/22575662/filename-too-long-in-git-for-windows/22575737>`__:
 
     *"Git has a limit of 4096 characters for a filename, except on Windows when Git is compiled with msys.*
     *It uses an older version of the Windows API and there's a limit of 260 characters for a filename.*
@@ -198,7 +198,7 @@ Other relevant discussions:
 * `"Comparison of Filesystems: Limits" (Wikipedia) <https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits>`__
 * `"Could the 100 byte path length limit be lifted?" (r-pkg-devel, 2023) <https://stat.ethz.ch/pipermail/r-package-devel/2023q4/010203.html>`__
 * `"R CMD check NOTE - Long paths in package" (r-pkg-devel, 2015) <https://stat.ethz.ch/pipermail/r-package-devel/2015q4/000511.html>`__
-* `"Filename length limits on linux?" (serverfault answer, 2009-2016) <https://serverfault.com/a/9548>`__
+* `"Filename length limits on linux?" (serverfault answer, 2009-2016) <https://serverfault.com/questions/9546/filename-length-limits-on-linux/9548>`__
 * `"Command prompt (Cmd. exe) command-line string limitation" (Windows docs, 2023) <https://learn.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/command-line-string-limitation>`__
 * `conda-build discussion about 255-character prefix limit (conda/conda-build#1482) <https://github.com/conda/conda-build/issues/1482#issuecomment-256530225>`__
 * `discussion about paths lengths (Python Discourse, 2023) <https://discuss.python.org/t/you-can-now-download-pypi-locally/32662/8>`__

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,4 +33,5 @@ html_static_path = ["_static"]
 linkcheck_anchors_ignore_for_url = [
     "https://github.com/conda/conda-build.*",
     "https://github.com/pypi/support/blob/.*",
+    "https://github.com/wch/r-source/blob/.*/check.R",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,3 +27,10 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
+
+# -- Options for linkcheck -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_anchors_ignore_for_url
+linkcheck_anchors_ignore_for_url = [
+    "https://github.com/conda/conda-build.*",
+    "https://github.com/pypi/support/blob/.*",
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,14 @@ html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
 
 # -- Options for linkcheck -------------------------------------------------
+
+# These UUIDs were randomly generated. They're just here because providing a non-empty dictionary
+# is necessary to achieve the behavior "fail on all redirects".
+# ref: https://github.com/sphinx-doc/sphinx/issues/13439
+linkcheck_allowed_redirects = {
+    "b4eb55a0-4de4-4643-a6fb-f95ec4bb1f54": "932edc12-3965-4d22-9dd7-b02e9210bf2c"
+}
+
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_anchors_ignore_for_url
 linkcheck_anchors_ignore_for_url = [
     "https://github.com/conda/conda-build.*",

--- a/docs/how-to-test-a-python-distribution.rst
+++ b/docs/how-to-test-a-python-distribution.rst
@@ -124,7 +124,7 @@ List of Tools
 
 The following open-source tools take packages as input, and can be used to detect (and in some cases repair) a wide range of Python packaging issues.
 
-* ``abi3audit`` (`link <https://github.com/trailofbits/abi3audit>`__) = detect ABI incompatibilities in wheels with CPython extensions
+* ``abi3audit`` (`link <https://github.com/pypa/abi3audit>`__) = detect ABI incompatibilities in wheels with CPython extensions
 * ``auditwheel`` (`link <https://github.com/pypa/auditwheel>`__) = detect and repair issues in Linux wheels that link to external shared libraries
 * ``auditwheel-emscripten`` (`link <https://github.com/ryanking13/auditwheel-emscripten>`__) = like ``auditwheel``, but focused on Python-in-a-web-browser applications (e.g. `pyodide auditwheel`_)
 * ``auditwheel-symbols`` (`link <https://github.com/messense/auditwheel-symbols>`__) = detect which symbols in a Linux wheel's shared library are causing ``auditwheel`` to suggest a more recent ``manylinux`` tag
@@ -138,7 +138,7 @@ The following open-source tools take packages as input, and can be used to detec
 * ``pyroma`` (`link <https://github.com/regebro/pyroma>`__) = detect incomplete or malformed metadata in sdists
 * ``repairwheel`` (`link <https://github.com/jvolkman/repairwheel>`__) = repair issues in Linux, macOS, and Windows wheels (wraps ``auditwheel``, ``delocate``, and ``delvewheel``)
 * ``twine`` (`link <https://github.com/pypa/twine>`__) = detect issues in package metadata (via ``twine check``)
-* ``wheel-inspect`` (`link <https://github.com/jwodder/wheel-inspect>`__) = dump summary information about wheels into machine-readable formats
+* ``wheel-inspect`` (`link <https://github.com/wheelodex/wheel-inspect>`__) = dump summary information about wheels into machine-readable formats
 
 And these take a source tree as input and find problems in the files uses to create packages.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 ``pydistcheck`` is a command-line interface (CLI) written in Python.
 
-Because of this, the preferred way to install it from PyPI is with ``pipx`` (`docs <https://pypa.github.io/pipx/>`_).
+Because of this, the preferred way to install it from PyPI is with ``pipx`` (`docs <https://pipx.pypa.io/stable/>`_).
 
 .. code-block:: shell
 

--- a/src/pydistcheck/_config.py
+++ b/src/pydistcheck/_config.py
@@ -53,6 +53,8 @@ _EXPECTED_FILES = (
     "!*/.gitignore",
     "!*/.gitpod.yml",
     "!*/.hadolint.yaml",
+    "!*/.lycheecache",
+    "!*/.lycheeignore",
     "!*/.readthedocs.yaml",
     "!*/.travis.yml",
     "!*/vsts-ci.yml",


### PR DESCRIPTION
fixes #293

Adds 2 types of link-checking:

1. in `sphinx` builds, for rendered docs ([via sphinx's built-in link checker](https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder))
2. for all files checked into source control ([with lychee](https://github.com/lycheeverse/lychee))

## Notes for Reviewers

### How I tested this

Saw this successfully catch some issues.

```text
[404] https://pypa.github.io/pipx/ | Network error: Not Found
```

([build link](https://github.com/jameslamb/pydistcheck/actions/runs/13802249162/job/38606655270?pr=312#step:4:98))