### PR TITLE
[ci] update packaging of licenses and license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: MacOS",
     "Operating System :: POSIX",
     "Operating System :: Unix",
@@ -35,6 +34,11 @@ keywords = [
     "python-packaging",
     "testing"
 ]
+license = "BSD-3-Clause"
+license-files = [
+    "LICENSE",
+    "LICENSES/*"
+]
 maintainers = [
   {name = "James Lamb", email = "jaylamb20@gmail.com"}
 ]
@@ -42,13 +46,6 @@ name = "pydistcheck"
 readme = "README.md"
 requires-python = ">=3.8"
 dynamic = ["version"]
-
-[tool.setuptools]
-# include-package-data = true
-license-files = [
-    "LICENSE",
-    "LICENSES/*"
-]
 
 [tool.setuptools.dynamic]
 version = {attr = "pydistcheck.__version__"}
@@ -70,7 +67,7 @@ changelog = "https://github.com/jameslamb/pydistcheck/releases"
 [build-system]
 
 requires = [
-    "setuptools>=75.0",
+    "setuptools>=77.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Fixes the following warning I noticed in CI during sdist building.

```text
/tmp/build-env-x41ecqxw/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:55: SetuptoolsDeprecationWarning: 'tool.setuptools.license-files' is deprecated in favor of 'project.license-files' (available on setuptools>=77.0.0).
!!

        ********************************************************************************

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-files for details.
        ********************************************************************************

!!
  _apply_tool_table(dist, config, filename)
/tmp/build-env-x41ecqxw/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!
```

([build link](https://github.com/jameslamb/pydistcheck/actions/runs/14233957361/job/39889778280?pr=316#step:7:172))

And then this one that I saw after updating the requirement to `setuptools>=77.0`.

```text
/private/var/folders/6d/80svzp0d0z1dr414fgnvll6h0000gn/T/build-env-zs6tgnb3/lib/python3.12/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: BSD License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
```