### PR TITLE
drop Python 3.8 support

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python_version: '3.8'
+            python_version: '3.9'
           - os: ubuntu-latest
             python_version: '3.13'
           - os: windows-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,8 +22,6 @@ jobs:
           # Linux #
           #########
           - os: ubuntu-latest
-            python_version: '3.8'
-          - os: ubuntu-latest
             python_version: '3.9'
           - os: ubuntu-latest
             python_version: '3.10'
@@ -37,14 +35,14 @@ jobs:
           # macOS #
           #########
           - os: macOS-13
-            python_version: '3.8'
+            python_version: '3.9'
           - os: macOS-latest
             python_version: '3.13'
           ###########
           # Windows #
           ###########
           - os: windows-latest
-            python_version: '3.8'
+            python_version: '3.9'
           - os: windows-latest
             python_version: '3.13'
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -40,7 +39,7 @@ maintainers = [
 ]
 name = "pydistcheck"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 
 [tool.setuptools]
@@ -100,7 +99,7 @@ ignore_directives = [
 [tool.ruff]
 line-length = 88
 # this should be set to the oldest version of python the project supports
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 ignore = [

--- a/src/pydistcheck/_config.py
+++ b/src/pydistcheck/_config.py
@@ -6,8 +6,9 @@ Manages configuration of ``pydistcheck` CLI, including:
 """
 
 import os
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Dict, Sequence
+from typing import Any
 
 from ._compat import tomllib
 
@@ -84,7 +85,7 @@ class _Config:
             )
         object.__setattr__(self, attr_name, value)
 
-    def update_from_dict(self, input_dict: Dict[str, Any]) -> "_Config":
+    def update_from_dict(self, input_dict: dict[str, Any]) -> "_Config":
         for k, v in input_dict.items():
             setattr(self, k, v)
         return self
@@ -93,7 +94,7 @@ class _Config:
         if not os.path.exists(toml_file):
             return self
 
-        tool_options: Dict[str, Any] = {}
+        tool_options: dict[str, Any] = {}
         with open(toml_file, "rb") as f:
             config_dict = tomllib.load(f)
             tool_options = config_dict.get("tool", {}).get("pydistcheck", {})

--- a/src/pydistcheck/_file_utils.py
+++ b/src/pydistcheck/_file_utils.py
@@ -3,7 +3,7 @@ import pathlib
 import tarfile
 import zipfile
 from dataclasses import dataclass
-from typing import List, Tuple, Union
+from typing import Union
 
 from ._compat import _import_zstandard
 
@@ -119,7 +119,7 @@ class _FileFormat:
 
 def _guess_archive_member_file_format(
     *, archive_file: Union[tarfile.TarFile, zipfile.ZipFile], member_name: str
-) -> Tuple[str, bool]:
+) -> tuple[str, bool]:
     """
     The approach in this function was inspired by similar code in
     https://github.com/matthew-brett/delocate, so that project's license is included
@@ -160,7 +160,7 @@ def _decompress_zstd_archive(*, tar_zst_file: str, decompressed_tar_path: str) -
 
 
 def _extract_subset_of_files_from_archive(
-    *, archive_file: str, archive_format: str, relative_paths: List[str], out_dir: str
+    *, archive_file: str, archive_format: str, relative_paths: list[str], out_dir: str
 ) -> None:
     """
     Extract a subset of files from an archive to a destination directory.

--- a/src/pydistcheck/_shared_lib_utils.py
+++ b/src/pydistcheck/_shared_lib_utils.py
@@ -4,7 +4,6 @@ functions used to analyze compiled objects
 
 import re
 import subprocess
-from typing import List, Tuple
 
 _COMMAND_FAILED = "__command_failed__"
 _NO_DEBUG_SYMBOLS = "__no_debug_symbols_found__"
@@ -16,7 +15,7 @@ _TOOL_NOT_AVAILABLE = "__tool_not_available__"
 _MACHO_STRIP_SYMBOL = "radr://5614542"
 
 
-def _run_command(args: List[str]) -> str:
+def _run_command(args: list[str]) -> str:
     try:
         stdout = subprocess.run(args, capture_output=True, check=True).stdout
         # Use latin1 encoding, which can handle any byte value without data loss.
@@ -50,7 +49,7 @@ _COMMANDS_TO_PATTERNS = [
 # fmt: on
 
 
-def _look_for_debug_symbols(lib_file: str) -> Tuple[bool, str]:
+def _look_for_debug_symbols(lib_file: str) -> tuple[bool, str]:
     for cmd_args, pattern in _COMMANDS_TO_PATTERNS:
         stdout = _run_command(args=[*cmd_args, lib_file])
         contains_debug_symbols = any(
@@ -62,20 +61,20 @@ def _look_for_debug_symbols(lib_file: str) -> Tuple[bool, str]:
     return False, _NO_DEBUG_SYMBOLS
 
 
-def _get_symbols(cmd_args: List[str], lib_file: str) -> str:
+def _get_symbols(cmd_args: list[str], lib_file: str) -> str:
     syms = _run_command(args=[*cmd_args, lib_file])
     return "\n".join(
         [line for line in syms.split("\n") if line and _MACHO_STRIP_SYMBOL not in line]
     )
 
 
-def _nm_reports_debug_symbols(tool_name: str, lib_file: str) -> Tuple[bool, str]:
+def _nm_reports_debug_symbols(tool_name: str, lib_file: str) -> tuple[bool, str]:
     exported_symbols = _get_symbols(cmd_args=[tool_name], lib_file=lib_file)
     all_symbols = _get_symbols(cmd_args=[tool_name, "-a"], lib_file=lib_file)
     return exported_symbols != all_symbols, f"{tool_name} -a"
 
 
-def _file_has_debug_symbols(file_absolute_path: str) -> Tuple[bool, str]:
+def _file_has_debug_symbols(file_absolute_path: str) -> tuple[bool, str]:
     # test with tools that produce debug symbols that can be matched with a regex
     has_debug_symbols, cmd_str = _look_for_debug_symbols(lib_file=file_absolute_path)
     if has_debug_symbols:

--- a/src/pydistcheck/_utils.py
+++ b/src/pydistcheck/_utils.py
@@ -4,7 +4,6 @@ not specific to package distributions
 """
 
 import re
-from typing import Tuple
 
 # references:
 #
@@ -25,7 +24,7 @@ _UNIT_TO_NUM_BYTES = {
 }
 
 
-def _recommend_size_str(num_bytes: int) -> Tuple[float, str]:
+def _recommend_size_str(num_bytes: int) -> tuple[float, str]:
     if num_bytes < int(0.1 * 1024):
         return float(num_bytes), "B"
     if num_bytes <= (0.1 * 1024**2):

--- a/src/pydistcheck/cli.py
+++ b/src/pydistcheck/cli.py
@@ -3,7 +3,7 @@ CLI entrypoints
 """
 
 import sys
-from typing import List, Sequence
+from collections.abc import Sequence
 
 import click
 
@@ -321,7 +321,7 @@ def check(  # noqa: PLR0913
             )
 
         print("------------ check results -----------")
-        errors: List[str] = []
+        errors: list[str] = []
         for this_check in checks:
             errors += this_check(distro_summary=summary)
 

--- a/tests/data/baseballmetrics/setup.cfg
+++ b/tests/data/baseballmetrics/setup.cfg
@@ -1,3 +1,3 @@
 [options]
 include_package_data = True
-python_requires = >=3.8
+python_requires = >=3.9


### PR DESCRIPTION
While trying to adapt to the new strong deprecation warnings from `setuptools` in #317, I found that the patterns that `setuptools` wants projects to use for license metadata requires `setuptools>=77.0`.

From https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html

> _Support for [project.license-files](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-files) and SPDX license expressions in [project.license](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license) ([PEP 639](https://peps.python.org/pep-0639/)) were introduced in version 77.0.0._

Unfortunately, that range of `setuptools` versions contains this change dropping Python 3.8 support: https://github.com/pypa/setuptools/commit/750a1891ec4a1c0602050e3463e9593a8c13aa14

To make all these things work together, in this PR I'm proposing dropping Python 3.8 support in the next release of `pydistcheck`. It's been end-of-life for 6 months ([October 2024](https://devguide.python.org/versions/)), I think it's ok.

## Notes for Reviewers

type-hint changes in this PR come from `pyupgrade` recommendations, as a result of updating the minimum version.