### PR TITLE
fix smoke tests

### DIFF
--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -46,7 +46,6 @@ pydistcheck \
     ./smoke-tests/*.conda
 pydistcheck \
     "${shared_args[@]}" \
-    --expected-directories='*/.github' \
     --expected-files='*/.gitignore' \
     ./smoke-tests/*.tar.gz
 pydistcheck \


### PR DESCRIPTION
Looks like `catboost` dropped the `.github/` directory from their sdists 🎉 

```text
checking './smoke-tests/catboost-1.2.8.tar.gz'
------------ check results -----------
1. [expected-files] Did not find any directories matching pattern '*/.github'.
errors found while checking: 1
```

([build link](https://github.com/jameslamb/pydistcheck/actions/runs/14478773322/job/40610788298#step:5:1418))