### PR TITLE
skip Stack Exchange sites in link checks, fix smoke tests

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -5,3 +5,8 @@ https://api.anaconda.org/package/%7BCONDA_CHANNEL%7D
 # special symbol added by 'strip' on macOS
 # (not actually a URL)
 radr://.*
+
+# Stack Exchange sites started throwing 403s around June 2025
+*serverfault.com*
+*stackoverflow.com*
+*superuser.com*

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -7,6 +7,6 @@ https://api.anaconda.org/package/%7BCONDA_CHANNEL%7D
 radr://.*
 
 # Stack Exchange sites started throwing 403s around June 2025
-*serverfault.com*
-*stackoverflow.com*
-*superuser.com*
+https://serverfault.com*
+https://stackoverflow.com*
+https://superuser.com*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         name: isort (python)
         args: ["--settings-path", "pyproject.toml"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.16.0
     hooks:
       - id: mypy
         args: ["--config-file", "pyproject.toml"]
@@ -27,7 +27,7 @@ repos:
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.2
+    rev: v0.11.12
     hooks:
       # Run the linter.
       - id: ruff
@@ -47,7 +47,7 @@ repos:
       - id: shellcheck
         args: ["--exclude=SC2002"]
   - repo: https://github.com/rstcheck/rstcheck
-    rev: v6.2.4
+    rev: v6.2.5
     hooks:
       - id: rstcheck
         args: ["--config=pyproject.toml"]
@@ -56,7 +56,7 @@ repos:
           - sphinx>=7.3
           - sphinx-click>=6.0
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.37.0
+    rev: v1.37.1
     hooks:
       - id: yamllint
         additional_dependencies: [pyyaml]

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -141,7 +141,6 @@ shared_args=(
 )
 pydistcheck \
     "${shared_args[@]}" \
-    --expected-files '*/.gitignore' \
     ./smoke-tests/*.tar.gz
 pydistcheck \
     "${shared_args[@]}" \

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -232,8 +232,8 @@ pydistcheck \
 get-files spacy
 pydistcheck \
     --ignore 'compiled-objects-have-debug-symbols' \
-    --max-allowed-size-compressed='50M' \
-    --max-allowed-size-uncompressed='100M' \
+    --max-allowed-size-compressed='100M' \
+    --max-allowed-size-uncompressed='200M' \
     ./smoke-tests/*
 
 echo "done running smoke tests"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,3 +43,9 @@ linkcheck_anchors_ignore_for_url = [
     "https://github.com/pypi/support/blob/.*",
     "https://github.com/wch/r-source/blob/.*/check.R",
 ]
+
+linkcheck_ignore = [
+    r".*serverfault\.com.*",
+    r".*stackoverflow\.com.*",
+    r".*superuser\.com.*",
+]


### PR DESCRIPTION
Stack Exchange sites started returning 403s some time in the last few weeks:

```text
( check-reference: line  201) broken    https://serverfault.com/questions/9546/filename-length-limits-on-linux/9548 - 403 Client Error: Forbidden for url: https://serverfault.com/questions/9546/filename-length-limits-on-linux/9548
( check-reference: line  188) broken    https://stackoverflow.com/questions/22575662/filename-too-long-in-git-for-windows/22575737 - 403 Client Error: Forbidden for url: https://stackoverflow.com/questions/22575662/filename-too-long-in-git-for-windows/22575737
( check-reference: line  153) broken    https://superuser.com/questions/29111/what-technical-reasons-exist-for-not-using-space-characters-in-file-names - 403 Client Error: Forbidden for url: https://superuser.com/questions/29111/what-technical-reasons-exist-for-not-using-space-characters-in-file-names
```

Totally unsubstantiated guess: that is some added protection those sites added against scraping for LLM projects.

This proposes skipping them in link checks.

Also fixes the smoke tests:

* looks like `airflow` no longer includes any `.gitingnore` files in its sdists 🎉 
* `spacy` wheels got a few MB larger