### PR TITLE
[ci] enable trusted publishing

### DIFF
--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -37,6 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     # publish whenever a GitHub release is published
     if: github.event_name == 'release' && github.event.action == 'published'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pydistcheck
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -47,9 +52,6 @@ jobs:
           name: wheel
           path: dist
       - uses: pypa/gh-action-pypi-publish@v1.12.4
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_KEY }}
 
   upload_github:
     needs: [upload_pypi]


### PR DESCRIPTION
Contributes to #323 

Sets up trusted publishing, following the documentation linked in #323.

## Notes for Reviewers

### Manual Stuff I did

1. set up a trusted publisher for this repo on the `pypi.org` project: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
2. created the `pypi` environment in the repo