### PR TITLE
bump development version to v0.10.0.99

### DIFF
--- a/src/pydistcheck/__init__.py
+++ b/src/pydistcheck/__init__.py
@@ -1,4 +1,4 @@
 # no one should be importing from this package
 __all__ = []  # type: ignore[var-annotated]
 
-__version__ = "0.10.0"
+__version__ = "0.10.0.99"


### PR DESCRIPTION
bump development version, following the `v0.10.0` release (#325)