### PR TITLE
make _FileSize hashable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         name: isort (python)
         args: ["--settings-path", "pyproject.toml"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.0
+    rev: v1.17.0
     hooks:
       - id: mypy
         args: ["--config-file", "pyproject.toml"]
@@ -27,7 +27,7 @@ repos:
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.12
+    rev: v0.12.5
     hooks:
       # Run the linter.
       - id: ruff
@@ -37,7 +37,7 @@ repos:
         args: ["--config", "pyproject.toml"]
         types_or: [python, jupyter]
   - repo: https://github.com/maxwinterstein/shfmt-py
-    rev: v3.11.0.2
+    rev: v3.12.0.1
     hooks:
       - id: shfmt
         args: ["--indent=4", "--space-redirects", "--write"]

--- a/src/pydistcheck/_compat.py
+++ b/src/pydistcheck/_compat.py
@@ -13,7 +13,7 @@ except ModuleNotFoundError:  # pragma: no cover
 
 def _import_zstandard() -> Any:
     try:
-        import zstandard
+        import zstandard  # noqa: PLC0415
 
         return zstandard
     except ModuleNotFoundError as err:

--- a/src/pydistcheck/_utils.py
+++ b/src/pydistcheck/_utils.py
@@ -74,6 +74,9 @@ class _FileSize:
             and self.total_size_bytes == other.total_size_bytes
         )
 
+    def __hash__(self) -> int:
+        return hash((self._num, self._unit_str))
+
     def __ge__(self, other: "_FileSize") -> bool:
         return self.total_size_bytes >= other.total_size_bytes
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -116,6 +116,23 @@ def test_file_size_to_string_works(precision, unit_str, expected_str):
     assert fs.to_string(precision=precision, unit_str=unit_str) == expected_str
 
 
+def test_file_is_hashable():
+    # same compare as same
+    assert {_FileSize(num=708, unit_str="Ki"), _FileSize(num=708, unit_str="Ki")} == {
+        _FileSize(num=708, unit_str="Ki")
+    }
+
+    # different (based on 'num') compare as different
+    assert (
+        len({_FileSize(num=100, unit_str="Ki"), _FileSize(num=999, unit_str="Ki")}) == 2
+    )
+
+    # different (based on 'unit_str') compare as different
+    assert (
+        len({_FileSize(num=100, unit_str="Ki"), _FileSize(num=100, unit_str="Mi")}) == 2
+    )
+
+
 @pytest.mark.parametrize(
     ("file_size", "expected_str"),
     [


### PR DESCRIPTION
Updating to the latest versions of all `pre-commit` hooks, `ruff` raised 2 new findings:

```text
src/pydistcheck/_compat.py:16:9: PLC0415 `import` should be at the top-level of a file
   |
14 | def _import_zstandard() -> Any:
15 |     try:
16 |         import zstandard
   |         ^^^^^^^^^^^^^^^^ PLC0415
17 |
18 |         return zstandard
   |

src/pydistcheck/_utils.py:38:7: PLW1641 Object does not implement `__hash__` method
   |
38 | class _FileSize:
   |       ^^^^^^^^^ PLW1641
39 |     def __init__(
40 |         self,
```

This addresses the `PLW1641` recommendation and makes `_FileSize` hashable.

See:

* https://docs.astral.sh/ruff/rules/eq-without-hash/
* https://docs.python.org/3/reference/datamodel.html#object.__hash__, namely: