### PR TITLE
[ci] update testing dependencies, fix smoke tests

### DIFF
--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           name: wheel
           path: dist
-      - uses: pypa/gh-action-pypi-publish@v1.12.4
+      - uses: pypa/gh-action-pypi-publish@v1.13.0
 
   upload_github:
     needs: [upload_pypi]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 'pypy${{ matrix.python_version}}'
       - name: Install extra tools on Linux
@@ -136,7 +136,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python_version}}"
       - name: run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-symlinks
@@ -10,13 +10,13 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+    rev: 6.1.0
     hooks:
       - id: isort
         name: isort (python)
         args: ["--settings-path", "pyproject.toml"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.0
+    rev: v1.18.2
     hooks:
       - id: mypy
         args: ["--config-file", "pyproject.toml"]
@@ -27,7 +27,7 @@ repos:
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.5
+    rev: v0.14.0
     hooks:
       # Run the linter.
       - id: ruff
@@ -42,7 +42,7 @@ repos:
       - id: shfmt
         args: ["--indent=4", "--space-redirects", "--write"]
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
         args: ["--exclude=SC2002"]

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -64,7 +64,7 @@ shared_args=(
     --ignore=compiled-objects-have-debug-symbols
     --ignore=mixed-file-extensions
     --ignore=path-contains-spaces
-    --max-allowed-files=8000
+    --max-allowed-files=8500
     --max-allowed-size-uncompressed=150M
 )
 pydistcheck \

--- a/src/pydistcheck/__init__.py
+++ b/src/pydistcheck/__init__.py
@@ -1,4 +1,4 @@
 # no one should be importing from this package
-__all__ = []  # type: ignore[var-annotated]
+__all__ = []
 
 __version__ = "0.10.0.99"


### PR DESCRIPTION
Updates all third-party GitHub Actions (closes #330).

Updates all `pre-commit` hooks with `pre-commit autoupdate`.

Fixes failing smoke tests.

## Notes for Reviewers

### issue 1: numpy sdists have more files

```text
checking './smoke-tests/numpy-2.3.3.tar.gz'
------------ check results -----------
1. [too-many-files] Found 8126 files. Only 8000 allowed.
errors found while checking: 1
```

([build link](https://github.com/jameslamb/pydistcheck/actions/runs/18329680374/job/52202130750#step:5:1565))