### PR TITLE
use 'compression.zstd' from the standard library when available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ pydistcheck = "pydistcheck.cli:check"
 
 [project.optional-dependencies]
 conda = [
-    "zstandard>=0.22.0"
+    "zstandard>=0.22.0 ; python_version < '3.14'"
 ]
 
 [project.urls]

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -5,4 +5,4 @@ pytest-cov
 requests
 twine
 types-requests
-zstandard
+zstandard ; python_version < '3.14'

--- a/src/pydistcheck/_compat.py
+++ b/src/pydistcheck/_compat.py
@@ -1,5 +1,5 @@
 """
-Central location for weird import stuff used to make the project compatible
+Central location for import stuff used to make the project compatible
 with a wide range of dependency versions.
 """
 
@@ -11,7 +11,7 @@ except ModuleNotFoundError:  # pragma: no cover
     import tomli as tomllib  # type: ignore[no-redef]
 
 
-def _import_zstandard() -> Any:
+def _import_zstandard() -> Any:  # pragma: no cover
     try:
         import zstandard  # noqa: PLC0415
 
@@ -19,7 +19,7 @@ def _import_zstandard() -> Any:
     except ModuleNotFoundError as err:
         err_msg = (
             "Checking zstd-compressed files requires the 'zstandard' library. "
-            "Install it with e.g. 'pip install zstandard' or 'conda install conda-forge::zstandard'."
+            "Install it with e.g. 'pip install zstandard' or 'conda install -c conda-forge zstandard'."
         )
         raise ModuleNotFoundError(err_msg) from err
 


### PR DESCRIPTION
Closes #331 

Starting with Python 3.14, the Python standard library has support for zstandard compression/decompression (see linked issue).

This PR proposes:

* using `compression.zstd` where it's available
* removing the dependency on `zstandard` in Python 3.14+ environments

## Notes for Reviewers

### Benefits of this change

Removes a third-party dependency in some environments, with all the benefits that entails (faster installs, smaller disk footprint, reduced risk of requirement conflicts, etc.).

`pydistcheck`'s need for handling zstd data is very very limited (a single decompression), so it really does not need all the power and flexibility of https://github.com/indygreg/python-zstandard

Thanks for making `compression.zstd` happen @emmatyping 😁 