### PR TITLE
[ci] enforce zizmor checks

### DIFF
--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -7,12 +7,31 @@ on:
     types:
       - published
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   build_wheels:
     name: build wheels
     runs-on: ubuntu-latest
+    permissions:
+      content: write
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Build wheels
         run: pipx run build --wheel
       - uses: actions/upload-artifact@v4
@@ -23,8 +42,12 @@ jobs:
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
+    permissions:
+      content: write
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Build sdist
         run: pipx run build --sdist
       - uses: actions/upload-artifact@v4
@@ -51,13 +74,16 @@ jobs:
         with:
           name: wheel
           path: dist
-      - uses: pypa/gh-action-pypi-publish@v1.13.0
+      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
 
   upload_github:
     needs: [upload_pypi]
     runs-on: ubuntu-latest
     # publish whenever a GitHub release is published
     if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      content: write
+      id-token: write
     steps:
       - uses: actions/download-artifact@v5
         with:
@@ -68,9 +94,9 @@ jobs:
           name: wheel
           path: dist
       - name: upload distributions to release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # 2.11.2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ github.token }}
           file: dist/*
           file_glob: true
           tag: ${{ github.ref }}

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -9,6 +9,21 @@ on:
     branches:
       - main
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   check-docs:
     name: check-docs
@@ -18,7 +33,8 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
-      - uses: conda-incubator/setup-miniconda@v3
+          persist-credentials: false
+      - uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.1.0
         with:
           environment-file: docs/env.yml
           activate-environment: pydistcheck-docs
@@ -41,8 +57,10 @@ jobs:
           key: cache-lychee-${{ github.sha }}
           restore-keys: cache-lychee-
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Lychee URL checker
-        uses: lycheeverse/lychee-action@v2.6.1
+        uses: lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2 # v2.6.1
         with:
           args: >-
             --cache
@@ -67,6 +85,6 @@ jobs:
       - check-links
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@v1.2.2
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,10 +1,28 @@
 name: check-labels
+
 on:
   pull_request:
-    types: [opened, labeled, unlabeled, synchronize]
-  # include PRs from forks
-  pull_request_target:
-    types: [opened, labeled, reopened, synchronize]
+    types:
+      - labeled
+      - opened
+      - synchronize
+      - unlabeled
+
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -13,7 +31,7 @@ jobs:
       issues: read
       pull-requests: read
     steps:
-      - uses: mheap/github-action-required-labels@v5
+      - uses: mheap/github-action-required-labels@fb29a14a076b0f74099f6198f77750e8fc236016 # v5.5.0
         with:
           mode: exactly
           add_comment: false

--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -9,6 +9,21 @@ on:
         required: true
         type: string
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   check-package:
     name: check-package
@@ -18,7 +33,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: check '${{ inputs.package_name }}'
+        env:
+          INPUT_PACKAGE_NAME: ${{ inputs.package_name }}
         run: |
           sudo apt-get update -y
           sudo apt-get install -y \
@@ -31,6 +49,6 @@ jobs:
           make install
           mkdir -p ./tmp-dir
           python bin/get-pypi-files.py\
-            ${{ inputs.package_name }} \
+            "${INPUT_PACKAGE_NAME}" \
             ./tmp-dir
           pydistcheck ./tmp-dir/*

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,12 +5,6 @@ on:
   push:
     branches:
       - main
-  # pull_request event is required only for autolabeler
-  pull_request:
-    types: [opened, reopened, synchronize]
-  # include PRs from forks
-  pull_request_target:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read
@@ -19,9 +13,10 @@ jobs:
   update_release_draft:
     permissions:
       contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          disable-autolabeler: true

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -12,6 +12,21 @@ on:
   schedule:
     - cron: '0 0 * * 3'
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   test:
     name: smoke-tests (${{ matrix.os }}, ${{ matrix.python_version }})
@@ -32,7 +47,8 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
-      - uses: conda-incubator/setup-miniconda@v3
+          persist-credentials: false
+      - uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.1.0
         with:
           activate-environment: pydistcheck-tests
           miniforge-version: latest
@@ -59,6 +75,6 @@ jobs:
       - test
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@v1.2.2
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,6 +9,21 @@ on:
     branches:
       - main
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   lint:
     name: lint
@@ -18,6 +33,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: run linting
         run: |
           export PATH="/usr/share/miniconda/bin:${PATH}"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,6 +9,21 @@ on:
     branches:
       - main
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   test-cpython:
     name: unit-tests (${{ matrix.os }}, Python-CPython ${{ matrix.python_version }})
@@ -54,7 +69,8 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
-      - uses: conda-incubator/setup-miniconda@v3
+          persist-credentials: false
+      - uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.1.0
         with:
           activate-environment: pydistcheck-tests
           miniforge-version: latest
@@ -99,6 +115,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: 'pypy${{ matrix.python_version}}'
@@ -138,6 +155,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python_version}}"
@@ -153,6 +171,6 @@ jobs:
       - check-test-packages
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@v1.2.2
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/isort
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: isort
         name: isort (python)
@@ -27,7 +27,7 @@ repos:
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.14.0
+    rev: v0.14.1
     hooks:
       # Run the linter.
       - id: ruff
@@ -80,3 +80,7 @@ repos:
     hooks:
       - id: cmakelint
         args: ["--linelength=120"]
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: 'v1.15.2'
+    hooks:
+      - id: zizmor


### PR DESCRIPTION
Closes #336 

This adds `zizmor` to the static analyzers run on every commit in this project, and fixes the issues it found with this project's GitHub Actions configuration.

* using commit SHAs instead of tags for third-part actions
* adding explicit `permissions:` blocks in all workflows, and limiting them to the least-privilege set necessary
* removing some unnecessary event triggers for the `release-drafter` workflow
* setting `persist-credentials: false` on any `actions/checkout` calls that don't need to be able to perform authenticated `git` actions after the initial checkout