### PR TITLE
improve readability of tracebacks, misc. other small linting improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,13 +26,10 @@ repos:
           - tomli>=1.1.0
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.14.1
+    rev: v0.14.3
     hooks:
-      # Run the linter.
       - id: ruff
         args: ["--config", "pyproject.toml"]
-      # Run the formatter.
       - id: ruff-format
         args: ["--config", "pyproject.toml"]
         types_or: [python, jupyter]
@@ -50,7 +47,7 @@ repos:
     rev: v6.2.5
     hooks:
       - id: rstcheck
-        args: ["--config=pyproject.toml"]
+        args: ["--config", "pyproject.toml"]
         additional_dependencies:
           - click>=8.0
           - sphinx>=7.3
@@ -81,6 +78,6 @@ repos:
       - id: cmakelint
         args: ["--linelength=120"]
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 'v1.15.2'
+    rev: 'v1.16.1'
     hooks:
       - id: zizmor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,8 @@ ignore = [
 select = [
     # flake8-builtins
     "A",
+    # flake8-annotations
+    "ANN",
     # flake8-bugbear
     "B",
     # flake8-comprehensions
@@ -125,6 +127,8 @@ select = [
     "DTZ",
     # pycodestyle
     "E",
+    # flake8-errmsg
+    "EM",
     # eradicate
     "ERA",
     # pyflakes
@@ -157,21 +161,28 @@ select = [
     "UP",
 ]
 
+[tool.ruff.lint.flake8-annotations]
+mypy-init-return = true
+
 [tool.ruff.lint.per-file-ignores]
 "src/pydistcheck/*.py" = [
-    # uses of tarfile.extractall()
+    # (flake8-bandit) uses of tarfile.extractall()
     "S202"
 ]
 "src/pydistcheck/cli.py" = [
-    # 'import' should be at the top-level of a file
+    # (pylint) 'import' should be at the top-level of a file
     "PLC0415",
-    # Too many branches
+    # (pylint) Too many branches
     "PLR0912",
-    # Too many statements
+    # (pylint) Too many statements
     "PLR0915"
 ]
+"src/pydistcheck/_compat.py" = [
+    # (flake8-annotations) typing.Any disallowed ... a bit complicated when a function returns a module
+    "ANN401"
+]
 "src/pydistcheck/_distribution_summary.py" = [
-    # Too many branches
+    # (pylint) Too many branches
     "PLR0912"
 ]
 "tests/*" = [

--- a/src/pydistcheck/_config.py
+++ b/src/pydistcheck/_config.py
@@ -8,7 +8,6 @@ Manages configuration of ``pydistcheck` CLI, including:
 import os
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
 
 from ._compat import tomllib
 
@@ -77,15 +76,14 @@ class _Config:
     output_file_size_unit: str = "auto"
     select: Sequence[str] = ()
 
-    def __setattr__(self, name: str, value: Any) -> None:
+    def __setattr__(self, name: str, value: object) -> None:
         attr_name = name.replace("-", "_")
         if attr_name not in _ALLOWED_CONFIG_VALUES:
-            raise ValueError(
-                f"Configuration value '{name}' is not recognized by pydistcheck"
-            )
+            msg = f"Configuration value '{name}' is not recognized by pydistcheck"
+            raise ValueError(msg)
         object.__setattr__(self, attr_name, value)
 
-    def update_from_dict(self, input_dict: dict[str, Any]) -> "_Config":
+    def update_from_dict(self, input_dict: dict[str, object]) -> "_Config":
         for k, v in input_dict.items():
             setattr(self, k, v)
         return self
@@ -94,7 +92,7 @@ class _Config:
         if not os.path.exists(toml_file):
             return self
 
-        tool_options: dict[str, Any] = {}
+        tool_options: dict[str, object] = {}
         with open(toml_file, "rb") as f:
             config_dict = tomllib.load(f)
             tool_options = config_dict.get("tool", {}).get("pydistcheck", {})

--- a/src/pydistcheck/_file_utils.py
+++ b/src/pydistcheck/_file_utils.py
@@ -32,11 +32,12 @@ def _guess_archive_format(filename: str) -> str:
     if filename.lower().endswith(".whl"):
         return _ArchiveFormat.ZIP
 
-    raise ValueError(
+    msg = (
         f"File '{filename}' does not appear to be a Python package distribution in "
         "one of the formats supported by 'pydistcheck'. "
         "Supported formats: .conda, .tar.bz2, .tar.gz, .whl, .zip"
     )
+    raise ValueError(msg)
 
 
 @dataclass

--- a/src/pydistcheck/_utils.py
+++ b/src/pydistcheck/_utils.py
@@ -54,7 +54,8 @@ class _FileSize:
     def from_string(cls, size_str: str) -> "_FileSize":
         parsed = re.search(r"^([0-9\.]+)([A-Za-z]+)$", size_str.strip())
         if parsed is None:
-            raise ValueError(f"Could not parse '{size_str}' as a file size.")
+            msg = f"Could not parse '{size_str}' as a file size."
+            raise ValueError(msg)
         return cls(num=float(parsed.group(1)), unit_str=parsed.group(2))
 
     def to_string(self, precision: int, unit_str: str) -> str:


### PR DESCRIPTION
Updates all `pre-commit` hooks to their latest versions, adds a few more `ruff` rules, and other small changes related to those.

## Notes for Reviewers

### New `ruff` rules

Ran the latest `ruff` with all checks selected, to see if there were any new findings that should be included in testing here. I found 2 that I liked:

```text
EM102 Exception must not use an f-string literal, assign to variable first
ANN401 Dynamically typed expressions (typing.Any) are disallowed in `_import_zstandard
```

`EM102` is helpful because code compliant with it has slightly easier-to-read tracebacks when exceptions are raised. See https://docs.astral.sh/ruff/rules/f-string-in-exception/

`ANN401` is helpful because it makes types a bit stricter and therefore type-checkers better able to find bugs. See https://docs.python.org/3.9/library/typing.html#the-any-type, which says:

> _Use [object](https://docs.python.org/3.9/library/functions.html#object) to indicate that a value could be any type in a typesafe manner. Use [Any](https://docs.python.org/3.9/library/typing.html#typing.Any) to indicate that a value is dynamically typed._

### Other misc. changes

* updated all `pre-commit` hooks
* removed uninformative comments from `.pre-commit-config.yaml`
* updated `ruff` config comments in `pyproject.toml` so all references to rule codes also clearly indicate the upstream project (like `flake8-annotations`) they're based on