### PR TITLE
[ci] fix broken links and smoke tests, add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     groups:
       ci-dependencies:
         patterns:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
           - tomli>=1.1.0
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.3
+    rev: v0.14.6
     hooks:
       - id: ruff
         args: ["--config", "pyproject.toml"]
@@ -78,6 +78,6 @@ repos:
       - id: cmakelint
         args: ["--linelength=120"]
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 'v1.16.1'
+    rev: 'v1.16.3'
     hooks:
       - id: zizmor

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -109,7 +109,7 @@ shared_args=(
     --ignore=compiled-objects-have-debug-symbols
     --ignore=mixed-file-extensions
     --ignore=path-contains-spaces
-    --max-allowed-files=4000
+    --max-allowed-files=4500
     --max-allowed-size-uncompressed=150M
 )
 pydistcheck \

--- a/docs/check-reference.rst
+++ b/docs/check-reference.rst
@@ -86,7 +86,7 @@ For example, several cloud function-as-a-service services allow uploading additi
 Python packages for use in function execution, with the following limits on their uncompressed size:
 
 * AWS Lambda: ``250 MB`` (`AWS docs <https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html>`__)
-* Google Cloud Functions: ``500 MB`` (`GCP docs <https://cloud.google.com/functions/quotas>`__)
+* Google Cloud Functions: ``500 MB`` (`GCP docs <https://docs.cloud.google.com/functions/quotas>`__)
 
 For a thorough discussion of some issues caused by larger distribution size, see `"FEEDBACK: PyArrow as a required dependency and PyArrow backed strings
 " (pandas-dev/pandas#54466) <https://github.com/pandas-dev/pandas/issues/54466>`__.


### PR DESCRIPTION
Looks like PR CI is broken (noticed on #342). This fixes that and includes a few other small updates.

* fixes a broken link
* fixes smoke tests (`cmake` wheels now contain many more files)
* updates `pre-commit` hooks to latest version
* adds a cooldown configuration for `dependabot`, to fix this:

```text
 INFO audit: zizmor: 🌈 completed .github/workflows/unit-tests.yml
warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
 --> .github/dependabot.yml:4:5
  |
4 |   - package-ecosystem: github-actions
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
  |
  = note: audit confidence → High
  = note: this finding has an auto-fix
```