### PR TITLE
[ci] update to macos-15 runners

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,7 +49,7 @@ jobs:
           #########
           # macOS #
           #########
-          - os: macOS-13
+          - os: macOS-15-intel
             python_version: *oldest_python
           - os: macOS-latest
             python_version: *latest_python
@@ -148,7 +148,7 @@ jobs:
         include:
           - os: ubuntu-slim
             python_version: '3.12'
-          - os: macOS-13
+          - os: macOS-15-intel
             python_version: '3.11'
     steps:
       - name: check out repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         name: isort (python)
         args: ["--settings-path", "pyproject.toml"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.0
+    rev: v1.19.1
     hooks:
       - id: mypy
         args: ["--config-file", "pyproject.toml"]
@@ -26,7 +26,7 @@ repos:
           - tomli>=1.1.0
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.8
+    rev: v0.14.10
     hooks:
       - id: ruff
         args: ["--config", "pyproject.toml"]
@@ -78,6 +78,6 @@ repos:
       - id: cmakelint
         args: ["--linelength=120"]
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 'v1.18.0'
+    rev: 'v1.19.0'
     hooks:
       - id: zizmor


### PR DESCRIPTION
The `macos-13` runners are now retired: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/