### PR TITLE
switch build backend to hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ changelog = "https://github.com/jameslamb/pydistcheck/releases"
 
 [build-system]
 requires = [
-    "hatchling>=1.28.0"
+    "hatchling>=1.27.0"
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
Switches the build backend from `setuptools` to `hatchling`.

Based on this documentation:

* https://hatch.pypa.io/latest/why/
* https://hatch.pypa.io/latest/config/build/

## Notes for Reviewers

### Why do this?

Honestly, it doesn't matter *too* much for this small, simple, pure-Python package. I mainly just wanted to get some experience with `hatchling`, and was relying on these recommendations:

* https://hatch.pypa.io/latest/why/
* https://packaging.python.org/en/latest/tutorials/packaging-projects/#choosing-a-build-backend
* https://www.pyopensci.org/python-package-guide/package-structure-code/python-package-build-tools.html#choosing-a-build-back-end

I like `hatchling`'s configuration options (especially the different "targets" for sdists and wheels) and it doesn't introduce significant new build dependencies.