### PR TITLE
update pre-commit hooks

### DIFF
--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -29,12 +29,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - name: Build wheels
         run: pipx run build --wheel
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: wheel
           path: dist/*.whl
@@ -45,12 +45,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - name: Build sdist
         run: pipx run build --sdist
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -66,11 +66,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: sdist
           path: dist
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: wheel
           path: dist
@@ -85,11 +85,11 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: sdist
           path: dist
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: wheel
           path: dist

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -51,12 +51,12 @@ jobs:
     steps:
       # cache Lychee results to avoid hitting rate limits
       - name: Restore lychee cache
-        uses: actions/cache@v5
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb  # v5.0.1
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
           restore-keys: cache-lychee-
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - name: Lychee URL checker

--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -44,7 +44,7 @@ jobs:
             python_version: '3.12'
     steps:
       - name: check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -66,7 +66,7 @@ jobs:
         shell: pwsh
         run: git config --global core.autocrlf false
       - name: check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -110,7 +110,7 @@ jobs:
             python_version: '3.11'
     steps:
       - name: check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -150,7 +150,7 @@ jobs:
             python_version: '3.11'
     steps:
       - name: check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
           - tomli>=1.1.0
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.14.11
     hooks:
       - id: ruff
         args: ["--config", "pyproject.toml"]
@@ -78,6 +78,6 @@ repos:
       - id: cmakelint
         args: ["--linelength=120"]
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 'v1.19.0'
+    rev: 'v1.20.0'
     hooks:
       - id: zizmor


### PR DESCRIPTION
Updates hooks with `pre-commit autoupdate`.

The latest `zizmor` now encourages the use of pinning to commit hashes for first-party actions (`actions/*`) so this adds that as well. ref: https://github.com/zizmorcore/zizmor/releases/tag/v1.20.0