### PR TITLE
run PyPI upload on ubuntu-latest runner

### DIFF
--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -57,7 +57,7 @@ jobs:
 
   upload_pypi:
     needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     # publish whenever a GitHub release is published
     if: github.event_name == 'release' && github.event.action == 'published'
     environment:


### PR DESCRIPTION
#351 broke the release. `pypa/gh-action-pypi-publish` requires `docker`

```text
Error: docker: command not found
```

([build link](https://github.com/jameslamb/pydistcheck/actions/runs/20908601592/job/60066968252#step:4:30))

This moves that CI job that pushes to PyPI back to `ubuntu-latest` to fix that.