### PR TITLE
fix smoke tests, bump dev version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
           - tomli>=1.1.0
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.11
+    rev: v0.14.14
     hooks:
       - id: ruff
         args: ["--config", "pyproject.toml"]
@@ -78,6 +78,6 @@ repos:
       - id: cmakelint
         args: ["--linelength=120"]
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 'v1.20.0'
+    rev: 'v1.22.0'
     hooks:
       - id: zizmor

--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -185,11 +185,6 @@ shared_args=(
 )
 pydistcheck \
     "${shared_args[@]}" \
-    --expected-directories '*/.github' \
-    --expected-files '*/.gitignore' \
-    ./smoke-tests/*.tar.gz
-pydistcheck \
-    "${shared_args[@]}" \
     ./smoke-tests/*.whl
 
 get-files pandas

--- a/src/pydistcheck/__init__.py
+++ b/src/pydistcheck/__init__.py
@@ -1,4 +1,4 @@
 # no one should be importing from this package
 __all__ = []
 
-__version__ = "0.11.3"
+__version__ = "0.11.3.99"


### PR DESCRIPTION
Fixes smoke tests... OpenCV didn't push sdists with its latest release (4.13.0.90):

```text
Error: Invalid value for '[FILEPATHS]...': Path './smoke-tests/*.tar.gz' does not exist.
```

([build link](https://github.com/jameslamb/pydistcheck/actions/runs/21554322206/job/62108039564?pr=362#step:5:641))

Also:

* bumps dev version now that the 0.11.3 release is out
* `pre-commit autoupdate`