### PR TITLE
fix smoke tests: 'cmake' size

### DIFF
--- a/bin/run-smoke-tests.sh
+++ b/bin/run-smoke-tests.sh
@@ -110,6 +110,7 @@ shared_args=(
     --ignore=mixed-file-extensions
     --ignore=path-contains-spaces
     --max-allowed-files=4500
+    --max-allowed-size-compressed=100M
     --max-allowed-size-uncompressed=150M
 )
 pydistcheck \


### PR DESCRIPTION
Fixes smoke tests

## Issue 1: `cmake` size

`cmake`'s universal2 macOS wheel is a bit bigger now, past the default limit `pydistcheck` sets.

```text
checking './smoke-tests/cmake-4.3.0-py3-none-macosx_10_10_universal2.whl'
------------ check results -----------
1. [distro-too-large-compressed] Compressed size 50.056M is larger than the allowed size (50.0M).
errors found while checking: 1
```

([build link](https://github.com/jameslamb/pydistcheck/actions/runs/23676487712/job/68980468150?pr=370))