### PR TITLE
[ci] use stricter GitHub Actions permissions

### DIFF
--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -7,27 +7,22 @@ on:
     types:
       - published
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# default to 0 permissions
+# (job-level overrides add the minimal permissions needed)
 permissions:
-  actions: none
-  checks: none
-  contents: read
-  deployments: none
-  discussions: none
-  id-token: none
-  issues: none
-  packages: none
-  pages: none
-  pull-requests: none
-  repository-projects: none
-  security-events: none
-  statuses: none
+  contents: none
 
 jobs:
   build_wheels:
     name: build wheels
     runs-on: ubuntu-slim
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -43,7 +38,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-slim
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -64,6 +59,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/pydistcheck
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -9,25 +9,22 @@ on:
     branches:
       - main
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# default to 0 permissions
+# (job-level overrides add the minimal permissions needed)
 permissions:
-  actions: none
-  checks: none
-  contents: read
-  deployments: none
-  discussions: none
-  id-token: none
-  issues: none
-  packages: none
-  pages: none
-  pull-requests: none
-  repository-projects: none
-  security-events: none
-  statuses: none
+  contents: none
 
 jobs:
   check-docs:
     name: check-docs
     runs-on: ubuntu-slim
+    permissions:
+      contents: read
     steps:
       - name: check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -48,6 +45,8 @@ jobs:
   check-links:
     name: check-links
     runs-on: ubuntu-slim
+    permissions:
+      contents: read
     steps:
       # cache Lychee results to avoid hitting rate limits
       - name: Restore lychee cache
@@ -83,6 +82,8 @@ jobs:
     needs:
       - check-docs
       - check-links
+    permissions:
+      statuses: read
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -8,20 +8,15 @@ on:
       - synchronize
       - unlabeled
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# default to 0 permissions
+# (job-level overrides add the minimal permissions needed)
 permissions:
-  actions: none
-  checks: none
-  contents: read
-  deployments: none
-  discussions: none
-  id-token: none
-  issues: none
-  packages: none
-  pages: none
-  pull-requests: none
-  repository-projects: none
-  security-events: none
-  statuses: none
+  contents: none
 
 jobs:
   check:

--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -9,25 +9,22 @@ on:
         required: true
         type: string
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# default to 0 permissions
+# (job-level overrides add the minimal permissions needed)
 permissions:
-  actions: none
-  checks: none
-  contents: read
-  deployments: none
-  discussions: none
-  id-token: none
-  issues: none
-  packages: none
-  pages: none
-  pull-requests: none
-  repository-projects: none
-  security-events: none
-  statuses: none
+  contents: none
 
 jobs:
   check-package:
     name: check-package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,8 +6,15 @@ on:
     branches:
       - main
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# default to 0 permissions
+# (job-level overrides add the minimal permissions needed)
 permissions:
-  contents: read
+  contents: none
 
 jobs:
   update_release_draft:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -12,20 +12,15 @@ on:
   schedule:
     - cron: '0 0 * * 3'
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# default to 0 permissions
+# (job-level overrides add the minimal permissions needed)
 permissions:
-  actions: none
-  checks: none
-  contents: read
-  deployments: none
-  discussions: none
-  id-token: none
-  issues: none
-  packages: none
-  pages: none
-  pull-requests: none
-  repository-projects: none
-  security-events: none
-  statuses: none
+  contents: none
 
 jobs:
   test:
@@ -42,6 +37,8 @@ jobs:
             python_version: '3.13'
           - os: windows-latest
             python_version: '3.12'
+    permissions:
+      contents: read
     steps:
       - name: check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -70,6 +67,8 @@ jobs:
     runs-on: ubuntu-slim
     needs:
       - test
+    permissions:
+      statuses: read
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,25 +9,22 @@ on:
     branches:
       - main
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# default to 0 permissions
+# (job-level overrides add the minimal permissions needed)
 permissions:
-  actions: none
-  checks: none
-  contents: read
-  deployments: none
-  discussions: none
-  id-token: none
-  issues: none
-  packages: none
-  pages: none
-  pull-requests: none
-  repository-projects: none
-  security-events: none
-  statuses: none
+  contents: none
 
 jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    permissions:
+      statuses: read
     steps:
       - name: check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,26 +9,23 @@ on:
     branches:
       - main
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# default to 0 permissions
+# (job-level overrides add the minimal permissions needed)
 permissions:
-  actions: none
-  checks: none
-  contents: read
-  deployments: none
-  discussions: none
-  id-token: none
-  issues: none
-  packages: none
-  pages: none
-  pull-requests: none
-  repository-projects: none
-  security-events: none
-  statuses: none
+  contents: none
 
 jobs:
   build:
     name: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -57,6 +54,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     needs: [build]
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -140,6 +139,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     needs: [build]
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -182,6 +183,8 @@ jobs:
     name: check-test-packages (${{ matrix.os }}, Python ${{ matrix.python_version }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -210,6 +213,8 @@ jobs:
       - check-test-packages
       - test-cpython
       - test-pypy
+    permissions:
+      statuses: read
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         name: isort (python)
         args: ["--settings-path", "pyproject.toml"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v1.20.0
     hooks:
       - id: mypy
         args: ["--config-file", "pyproject.toml"]
@@ -26,7 +26,7 @@ repos:
           - tomli>=1.1.0
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.7
+    rev: v0.15.9
     hooks:
       - id: ruff
         args: ["--config", "pyproject.toml"]


### PR DESCRIPTION
Follow-up to #337 

* stricter permissions (e.g. `actions/upload-artifact` does not require `contents: write`)
* concurrency groups for all workflows
* updates all `pre-commit` hooks